### PR TITLE
feat : #13 개별 에셋

### DIFF
--- a/src/main/java/com/phoenix/assetbe/controller/AssetController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/AssetController.java
@@ -6,6 +6,9 @@ import com.phoenix.assetbe.dto.asset.AssetResponse;
 import com.phoenix.assetbe.service.AssetService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,6 +24,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class AssetController {
 
     private final AssetService assetService;
+
+    @GetMapping("/assets")
+    public ResponseEntity<?> getAssets(@PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
+                                       @AuthenticationPrincipal MyUserDetails myUserDetails) {
+
+        AssetResponse.AssetsOutDTO assetsOutDTO = assetService.getAssetsService(pageable, myUserDetails);
+        ResponseDTO<?> responseDTO = new ResponseDTO<>(assetsOutDTO);
+        return ResponseEntity.ok().body(responseDTO);
+    }
 
     @GetMapping("/assets/{id}")
     public ResponseEntity<?> getAssetDetails(@PathVariable Long id,

--- a/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
@@ -3,9 +3,9 @@ package com.phoenix.assetbe.dto.asset;
 import com.phoenix.assetbe.model.asset.Asset;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public class AssetResponse {
@@ -83,21 +83,22 @@ public class AssetResponse {
 
     @Getter @Setter
     public static class AssetsOutDTO {
-        private List<AssetDetail> assetList;
-        private Long size;
-        private Long currentPage;
-        private Long totalPage;
-        private Long totalElement;
+        private List<?> assetList;
+        private int size;
+        private int currentPage;
+        private int totalPage;
+        private long totalElement;
 
-        public AssetsOutDTO(List<AssetDetail> assetList, Long size, Long currentPage, Long totalPage, Long totalElement) {
-            this.assetList = assetList;
-            this.size = size;
-            this.currentPage = currentPage;
-            this.totalPage = totalPage;
-            this.totalElement = totalElement;
+        public AssetsOutDTO(Page<?> assetList) {
+            this.assetList = assetList.getContent();
+            this.size = assetList.getSize();
+            this.currentPage = assetList.getPageable().getPageNumber();
+            this.totalPage = assetList.getTotalPages();
+            this.totalElement = assetList.getTotalElements();
         }
 
-        @Getter @Setter
+        @Getter
+        @Setter
         public static class AssetDetail {
             private Long assetId;
             private String assetName;
@@ -108,6 +109,18 @@ public class AssetResponse {
             private Long wishCount;
             private Long wishlistId;
             private Long cartId;
+
+            public AssetDetail(Long assetId, String assetName, Double price,
+                               LocalDate releaseDate, Double rating, Long reviewCount,
+                               Long wishCount) {
+                this.assetId = assetId;
+                this.assetName = assetName;
+                this.price = price;
+                this.releaseDate = releaseDate;
+                this.rating = rating;
+                this.reviewCount = reviewCount;
+                this.wishCount = wishCount;
+            }
 
             public AssetDetail(Long assetId, String assetName, Double price,
                                LocalDate releaseDate, Double rating, Long reviewCount,

--- a/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
@@ -4,6 +4,8 @@ import com.phoenix.assetbe.model.asset.Asset;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class AssetResponse {
@@ -76,6 +78,50 @@ public class AssetResponse {
             this.visitCount = asset.getVisitCount();
             this.wishlistId = wishlistId;
             this.tagList = tagList;
+        }
+    }
+
+    @Getter @Setter
+    public static class AssetsOutDTO {
+        private List<AssetDetail> assetList;
+        private Long size;
+        private Long currentPage;
+        private Long totalPage;
+        private Long totalElement;
+
+        public AssetsOutDTO(List<AssetDetail> assetList, Long size, Long currentPage, Long totalPage, Long totalElement) {
+            this.assetList = assetList;
+            this.size = size;
+            this.currentPage = currentPage;
+            this.totalPage = totalPage;
+            this.totalElement = totalElement;
+        }
+
+        @Getter @Setter
+        public static class AssetDetail {
+            private Long assetId;
+            private String assetName;
+            private Double price;
+            private LocalDate releaseDate;
+            private Double rating;
+            private Long reviewCount;
+            private Long wishCount;
+            private Long wishlistId;
+            private Long cartId;
+
+            public AssetDetail(Long assetId, String assetName, Double price,
+                               LocalDate releaseDate, Double rating, Long reviewCount,
+                               Long wishCount, Long wishlistId, Long cartId) {
+                this.assetId = assetId;
+                this.assetName = assetName;
+                this.price = price;
+                this.releaseDate = releaseDate;
+                this.rating = rating;
+                this.reviewCount = reviewCount;
+                this.wishCount = wishCount;
+                this.wishlistId = wishlistId;
+                this.cartId = cartId;
+            }
         }
     }
 }

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
@@ -1,0 +1,32 @@
+package com.phoenix.assetbe.model.asset;
+
+import com.phoenix.assetbe.dto.asset.AssetResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.phoenix.assetbe.model.asset.QAsset.asset;
+import static com.phoenix.assetbe.model.cart.QCart.cart;
+import static com.phoenix.assetbe.model.wish.QWishList.wishList;
+
+@RequiredArgsConstructor
+@Repository
+public class AssetQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public List<AssetResponse.AssetsOutDTO.AssetDetail> findAssetWithPaging(Long userId){
+        return queryFactory
+                .select(Projections.constructor(AssetResponse.AssetsOutDTO.AssetDetail.class,
+                        asset.id, asset.assetName, asset.price, asset.releaseDate, asset.rating, asset.reviewCount,
+                        asset.wishCount, wishList.id, cart.id))
+                .from(asset)
+                .leftJoin(wishList).on(wishList.asset.id.eq(asset.id)).on(wishList.user.id.eq(userId))
+                .leftJoin(cart).on(cart.asset.id.eq(asset.id)).on(cart.user.id.eq(userId))
+                .orderBy(asset.releaseDate.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
@@ -1,10 +1,15 @@
 package com.phoenix.assetbe.model.asset;
 
 import com.phoenix.assetbe.dto.asset.AssetResponse;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,15 +23,66 @@ import static com.phoenix.assetbe.model.wish.QWishList.wishList;
 public class AssetQueryRepository {
     private final JPAQueryFactory queryFactory;
 
-    public List<AssetResponse.AssetsOutDTO.AssetDetail> findAssetWithPaging(Long userId){
-        return queryFactory
+    public Page<AssetResponse.AssetsOutDTO.AssetDetail> findAssetsWithUserIdAndPaging(Long userId, Pageable pageable){
+        List <AssetResponse.AssetsOutDTO.AssetDetail> result = queryFactory
                 .select(Projections.constructor(AssetResponse.AssetsOutDTO.AssetDetail.class,
                         asset.id, asset.assetName, asset.price, asset.releaseDate, asset.rating, asset.reviewCount,
                         asset.wishCount, wishList.id, cart.id))
                 .from(asset)
                 .leftJoin(wishList).on(wishList.asset.id.eq(asset.id)).on(wishList.user.id.eq(userId))
                 .leftJoin(cart).on(cart.asset.id.eq(asset.id)).on(cart.user.id.eq(userId))
-                .orderBy(asset.releaseDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(assetSort(pageable))
                 .fetch();
+
+        Long totalCount = queryFactory.select(asset.count())
+                .from(asset)
+                .fetchOne();
+
+        return new PageImpl<>(result, pageable, totalCount);
+    }
+
+    public Page<AssetResponse.AssetsOutDTO.AssetDetail> findAssetsWithPaging(Pageable pageable){
+        List <AssetResponse.AssetsOutDTO.AssetDetail> result = queryFactory
+                .select(Projections.constructor(AssetResponse.AssetsOutDTO.AssetDetail.class,
+                        asset.id, asset.assetName, asset.price, asset.releaseDate, asset.rating, asset.reviewCount,
+                        asset.wishCount))
+                .from(asset)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(assetSort(pageable))
+                .fetch();
+
+        Long totalCount = queryFactory.select(asset.count())
+                .from(asset)
+                .fetchOne();
+
+        return new PageImpl<>(result, pageable, totalCount);
+    }
+
+    private OrderSpecifier<?> assetSort(Pageable pageable) {
+        if (!pageable.getSort().isEmpty()) {
+            for (Sort.Order order : pageable.getSort()) {
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                switch (order.getProperty()){
+                    case "id":
+                        return new OrderSpecifier<>(direction, asset.id);
+                    case "assetName":
+                        return new OrderSpecifier<>(direction, asset.assetName);
+                    case "price":
+                        return new OrderSpecifier<>(direction, asset.price);
+                    case "releaseDate":
+                        return new OrderSpecifier<>(direction, asset.releaseDate);
+                    case "rating":
+                        return new OrderSpecifier<>(direction, asset.rating);
+                    case "reviewCount":
+                        return new OrderSpecifier<>(direction, asset.reviewCount);
+                    case "wishCount":
+                        return new OrderSpecifier<>(direction, asset.wishCount);
+                }
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/phoenix/assetbe/service/AssetService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AssetService.java
@@ -12,6 +12,7 @@ import com.phoenix.assetbe.model.wish.WishListRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,10 +31,16 @@ public class AssetService {
     private final AssetTagQueryRepository assetTagQueryRepository;
 
     public AssetResponse.AssetsOutDTO getAssetsService(Pageable pageable, MyUserDetails myUserDetails) {
-        Long userId = myUserDetails.getUser().getId();
-        List<AssetResponse.AssetsOutDTO.AssetDetail> assetDetails = assetQueryRepository.findAssetWithPaging(userId);
-        return new AssetResponse.AssetsOutDTO(assetDetails,null,null,null,null);
+        Page<AssetResponse.AssetsOutDTO.AssetDetail> assetDetails;
+        if(myUserDetails != null) {
+            Long userId = myUserDetails.getUser().getId();
+            assetDetails = assetQueryRepository.findAssetsWithUserIdAndPaging(userId, pageable);
+        }else {
+            assetDetails = assetQueryRepository.findAssetsWithPaging(pageable);
+        }
+        return new AssetResponse.AssetsOutDTO(assetDetails);
     }
+
     @Transactional
     public AssetResponse.AssetDetailsOutDTO getAssetDetailsService(Long assetId, MyUserDetails myUserDetails) {
         Long wishListId = null;

--- a/src/main/java/com/phoenix/assetbe/service/AssetService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AssetService.java
@@ -3,6 +3,7 @@ package com.phoenix.assetbe.service;
 import com.phoenix.assetbe.core.auth.session.MyUserDetails;
 import com.phoenix.assetbe.core.exception.Exception400;
 import com.phoenix.assetbe.model.asset.Asset;
+import com.phoenix.assetbe.model.asset.AssetQueryRepository;
 import com.phoenix.assetbe.model.asset.AssetRepository;
 import com.phoenix.assetbe.dto.asset.AssetResponse;
 import com.phoenix.assetbe.core.exception.Exception500;
@@ -11,6 +12,7 @@ import com.phoenix.assetbe.model.wish.WishListRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,9 +25,15 @@ import java.util.List;
 public class AssetService {
 
     private final AssetRepository assetRepository;
+    private final AssetQueryRepository assetQueryRepository;
     private final WishListRepository wishListRepository;
     private final AssetTagQueryRepository assetTagQueryRepository;
 
+    public AssetResponse.AssetsOutDTO getAssetsService(Pageable pageable, MyUserDetails myUserDetails) {
+        Long userId = myUserDetails.getUser().getId();
+        List<AssetResponse.AssetsOutDTO.AssetDetail> assetDetails = assetQueryRepository.findAssetWithPaging(userId);
+        return new AssetResponse.AssetsOutDTO(assetDetails,null,null,null,null);
+    }
     @Transactional
     public AssetResponse.AssetDetailsOutDTO getAssetDetailsService(Long assetId, MyUserDetails myUserDetails) {
         Long wishListId = null;

--- a/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
@@ -2,6 +2,8 @@ package com.phoenix.assetbe.controller;
 
 import com.phoenix.assetbe.dto.asset.AssetResponse;
 import com.phoenix.assetbe.model.asset.*;
+import com.phoenix.assetbe.model.cart.Cart;
+import com.phoenix.assetbe.model.cart.CartRepository;
 import com.phoenix.assetbe.model.user.*;
 import com.phoenix.assetbe.model.wish.WishList;
 import com.phoenix.assetbe.model.wish.WishListRepository;
@@ -70,6 +72,9 @@ public class AssetControllerTest {
 
     @Autowired
     private WishListRepository wishListRepository;
+
+    @Autowired
+    private CartRepository cartRepository;
 
     @Autowired
     private UserRepository userRepository;
@@ -160,6 +165,17 @@ public class AssetControllerTest {
         WishList w9 = WishList.builder().asset(a9).user(u3).build();
         wishListRepository.saveAll(Arrays.asList(w1, w2, w3, w4, w5, w6, w7, w8, w9));
 
+        Cart cart1 = Cart.builder().asset(a1).user(u1).build();
+        Cart cart2 = Cart.builder().asset(a1).user(u2).build();
+        Cart cart3 = Cart.builder().asset(a1).user(u3).build();
+        Cart cart4 = Cart.builder().asset(a2).user(u1).build();
+        Cart cart5 = Cart.builder().asset(a2).user(u2).build();
+        Cart cart6 = Cart.builder().asset(a2).user(u3).build();
+        Cart cart7 = Cart.builder().asset(a4).user(u1).build();
+        Cart cart8 = Cart.builder().asset(a5).user(u1).build();
+        Cart cart9 = Cart.builder().asset(a9).user(u1).build();
+        cartRepository.saveAll(Arrays.asList(cart1,cart2,cart3,cart4,cart5,cart6,cart7,cart8,cart9));
+
         em.clear();
     }
 
@@ -203,16 +219,40 @@ public class AssetControllerTest {
                 .andExpect(jsonPath("$.data.visitCount").value(10001L));
     }
 
-    @DisplayName("에셋 상세정보 로그인 성공")
+    @DisplayName("개별에셋 로그인 성공")
     @WithUserDetails(value = "user1@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
-    public void get_assets_test() throws Exception {
+    public void get_assets_with_user_test() throws Exception {
         // given
-        Long id = 1L;
+        String page = "0";
+        String size = "4";
 
         // when
         ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets"));
+                .get("/assets")
+                .param("page", page)
+                .param("size", size));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200));
+    }
+
+    @DisplayName("개별에셋 비로그인 성공")
+    @Test
+    public void get_assets_test() throws Exception {
+        // given
+        String page = "0";
+        String size = "4";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .get("/assets")
+                .param("page", page)
+                .param("size", size));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
         System.out.println("테스트 : " + responseBody);
 

--- a/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
+++ b/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
@@ -13,6 +13,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
@@ -194,22 +198,23 @@ public class AssetQueryRepositoryTest {
     public void find_assets_test() {
         //Given
         Long userId = 1L;
-//        int page = 0;
-//        int size = 3;
-//        Pageable pageable = PageRequest.of(page, size, Sort.Direction.DESC);
+        int page = 0;
+        int size = 3;
+        Pageable pageable = PageRequest.of(page, size, Sort.by("releaseDate").descending());
 
-        List<AssetResponse.AssetsOutDTO.AssetDetail> result = assetQueryRepository.findAssetWithPaging(userId);
+        Page<AssetResponse.AssetsOutDTO.AssetDetail> result = assetQueryRepository.findAssetsWithUserIdAndPaging(userId, pageable);
 
         //then
-        assertThat(result.size(), is(9));
-        assertThat(result.get(8).getAssetId(), is(1L));
-        assertThat(result.get(8).getWishlistId(), is(1L));
-        assertThat(result.get(8).getCartId(), is(1L));
-        assertThat(result.get(7).getAssetId(), is(2L));
-        assertNull(result.get(7).getWishlistId());
-        assertThat(result.get(7).getCartId(), is(4L));
-        assertThat(result.get(6).getAssetId(), is(3L));
-        assertThat(result.get(6).getWishlistId(), is(2L));
-        assertNull(result.get(6).getCartId());
+//        assertThat(result.size(), is(9)); //페이징 하기전 테스트
+        assertThat(result.getContent().size(), is(3));
+        assertThat(result.getContent().get(0).getAssetId(), is(9L));
+        assertNull(result.getContent().get(0).getWishlistId());
+        assertThat(result.getContent().get(0).getCartId(), is(9L));
+        assertThat(result.getContent().get(1).getAssetId(), is(8L));
+        assertNull(result.getContent().get(1).getWishlistId());
+        assertNull(result.getContent().get(1).getCartId());
+        assertThat(result.getContent().get(2).getAssetId(), is(7L));
+        assertThat(result.getContent().get(2).getWishlistId(), is(5L));
+        assertNull(result.getContent().get(2).getCartId());
     }
 }


### PR DESCRIPTION
## Motivation

- 개별 에셋을 조회하고 응답한다.

resolved #13 

## Proposed Changes

- 로그인, 비로그인을 구분한다.
- 로그인 유저의 경우 그 에셋이 위시리스트나 카트에 있으면 
  위시리스트 id와 카트 id를 같이 응답해서 화면에 상태를 표시할 수 있도록 한다.
- 비로그인 유저의 경우 두 id 값은 null이다.
- 릴리즈 날짜 내림차순 정렬
- 페이지네이션