### PR TITLE
feat : #14 상위 카테고리별 에셋 조회

### DIFF
--- a/src/main/java/com/phoenix/assetbe/controller/AssetController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/AssetController.java
@@ -43,4 +43,16 @@ public class AssetController {
         ResponseDTO<?> responseDTO = new ResponseDTO<>(assetDetailsOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
+
+    @GetMapping("/assets/{categoryName}")
+    public ResponseEntity<?> getAssetListByCategory(
+            @PathVariable String categoryName,
+            @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal MyUserDetails myUserDetails) {
+
+        AssetResponse.AssetsOutDTO assetsOutDTO =
+                assetService.getAssetListByCategoryService(categoryName, pageable, myUserDetails);
+        ResponseDTO<?> responseDTO = new ResponseDTO<>(assetsOutDTO);
+        return ResponseEntity.ok().body(responseDTO);
+    }
 }

--- a/src/main/java/com/phoenix/assetbe/controller/AssetController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/AssetController.java
@@ -34,7 +34,7 @@ public class AssetController {
         return ResponseEntity.ok().body(responseDTO);
     }
 
-    @GetMapping("/assets/{id}")
+    @GetMapping("/assets/{id}/details")
     public ResponseEntity<?> getAssetDetails(@PathVariable Long id,
                                              @AuthenticationPrincipal MyUserDetails myUserDetails) {
 

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetCategoryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetCategoryRepository.java
@@ -1,0 +1,6 @@
+package com.phoenix.assetbe.model.asset;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AssetCategoryRepository extends JpaRepository<AssetCategory, Long> {
+}

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetTagQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetTagQueryRepository.java
@@ -14,7 +14,7 @@ import static com.phoenix.assetbe.model.asset.QTag.tag;
 public class AssetTagQueryRepository {
     private final JPAQueryFactory queryFactory;
 
-    public List<String> findTagNamesByAssetId(Long assetId) {
+    public List<String> findTagNameListByAssetId(Long assetId) {
         return queryFactory.selectDistinct(assetTag.tag.tagName)
                 .from(assetTag)
                 .join(assetTag.tag, tag)

--- a/src/main/java/com/phoenix/assetbe/service/AssetService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AssetService.java
@@ -59,6 +59,17 @@ public class AssetService {
         return new AssetResponse.AssetDetailsOutDTO(assetPS, wishListId, tagNameList);
     }
 
+    public AssetResponse.AssetsOutDTO getAssetListByCategoryService(String categoryName, Pageable pageable, MyUserDetails myUserDetails) {
+        Page<AssetResponse.AssetsOutDTO.AssetDetail> assetDetailList;
+        if(myUserDetails != null) {
+            Long userId = myUserDetails.getUser().getId();
+            assetDetailList = assetQueryRepository.findAssetListWithUserIdAndPaginationByCategory(userId, categoryName, pageable);
+        }else {
+            assetDetailList = assetQueryRepository.findAssetListWithPaginationByCategory(categoryName, pageable);
+        }
+        return new AssetResponse.AssetsOutDTO(assetDetailList);
+    }
+
     public Asset findAssetById(Long assetId){
         Asset assetPS = assetRepository.findById(assetId).orElseThrow(
                 () -> new Exception400("id", "존재하지 않는 에셋입니다. "));

--- a/src/main/java/com/phoenix/assetbe/service/AssetService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AssetService.java
@@ -49,7 +49,7 @@ public class AssetService {
             wishListId = wishListRepository.findIdByAssetIdAndUserId(assetId, userId);
         }
         Asset assetPS = findAssetById(assetId);
-        List<String> tagNameList = assetTagQueryRepository.findTagNamesByAssetId(assetId);
+        List<String> tagNameList = assetTagQueryRepository.findTagNameListByAssetId(assetId);
         assetPS.increaseVisitCount();
         try {
             assetRepository.save(assetPS);

--- a/src/main/resources/static/docs/api-docs.html
+++ b/src/main/resources/static/docs/api-docs.html
@@ -445,7 +445,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-06-13 16:14:11 +0900
+Last updated 2023-06-07 09:57:19 +0900
 </div>
 </div>
 </body>

--- a/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
@@ -187,7 +187,7 @@ public class AssetControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets/{id}",id).with(anonymous()));
+                .get("/assets/{id}/details",id));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
         System.out.println("테스트 : " + responseBody);
 
@@ -207,7 +207,7 @@ public class AssetControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets/{id}",id));
+                .get("/assets/{id}/details",id));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
         System.out.println("테스트 : " + responseBody);
 

--- a/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
@@ -71,6 +71,9 @@ public class AssetControllerTest {
     private TagRepository tagRepository;
 
     @Autowired
+    private AssetCategoryRepository assetCategoryRepository;
+
+    @Autowired
     private WishListRepository wishListRepository;
 
     @Autowired
@@ -122,6 +125,17 @@ public class AssetControllerTest {
         Tag t5 = Tag.builder().tagName("tag5").tagCount(300L).build();
         Tag t6 = Tag.builder().tagName("tag6").tagCount(300L).build();
         tagRepository.saveAll(Arrays.asList(t1, t2, t3, t4, t5, t6));
+
+        AssetCategory ac1 = AssetCategory.builder().asset(a1).category(c1).build();
+        AssetCategory ac2 = AssetCategory.builder().asset(a2).category(c2).build();
+        AssetCategory ac3 = AssetCategory.builder().asset(a3).category(c3).build();
+        AssetCategory ac4 = AssetCategory.builder().asset(a4).category(c1).build();
+        AssetCategory ac5 = AssetCategory.builder().asset(a5).category(c2).build();
+        AssetCategory ac6 = AssetCategory.builder().asset(a6).category(c3).build();
+        AssetCategory ac7 = AssetCategory.builder().asset(a7).category(c1).build();
+        AssetCategory ac8 = AssetCategory.builder().asset(a8).category(c2).build();
+        AssetCategory ac9 = AssetCategory.builder().asset(a9).category(c3).build();
+        assetCategoryRepository.saveAll(Arrays.asList(ac1,ac2,ac3,ac4,ac5,ac6,ac7,ac8,ac9));
 
         AssetTag at1 = AssetTag.builder().asset(a1).category(c1).subCategory(sc1).tag(t1).build();
         AssetTag at2 = AssetTag.builder().asset(a1).category(c1).subCategory(sc1).tag(t2).build();
@@ -226,7 +240,6 @@ public class AssetControllerTest {
         // given
         String page = "0";
         String size = "4";
-
         // when
         ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
                 .get("/assets")
@@ -251,6 +264,51 @@ public class AssetControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
                 .get("/assets")
+                .param("page", page)
+                .param("size", size));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200));
+    }
+
+    @DisplayName("카테고리별 에셋 조회 로그인 성공")
+    @WithUserDetails(value = "user1@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void get_asset_list_with_user_id_and_pagination_by_category_test() throws Exception {
+        // given
+        String categoryName = "A";
+        String page = "0";
+        String size = "4";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .get("/assets/{categoryName}",categoryName)
+                .param("page", page)
+                .param("size", size));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200));
+    }
+
+    @DisplayName("카테고리별 에셋 조회 비로그인 성공")
+    @Test
+    public void get_asset_list_with_pagination_by_category_test() throws Exception {
+        // given
+        String categoryName = "A";
+        String page = "0";
+        String size = "4";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .get("/assets/{categoryName}",categoryName)
                 .param("page", page)
                 .param("size", size));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();


### PR DESCRIPTION
## Motivation

- 상위 카테고리별 에셋을 조회한다.

resolved #14 

## Proposed Changes

- 비로그인 사용자와 로그인 사용자를 구분한다.
- 상위 카테고리별 에셋 조회를 구현한다
- 로그인 사용자이면 에셋에 찜한 상태, 장바구니 상태를 포함시킨다.
- 정렬 : 에셋 릴리즈날짜 기준 내림차순
- 페이지네이션 : 기본 page=0 & size=28

