### PR TITLE
feat : #24 하위 카테고리별 에셋 조회

### DIFF
--- a/src/main/java/com/phoenix/assetbe/controller/AssetController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/AssetController.java
@@ -55,4 +55,17 @@ public class AssetController {
         ResponseDTO<?> responseDTO = new ResponseDTO<>(assetsOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
+
+    @GetMapping("/assets/{categoryName}/{subCategoryName}")
+    public ResponseEntity<?> getAssetListBySubCategory(
+            @PathVariable String categoryName,
+            @PathVariable String subCategoryName,
+            @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal MyUserDetails myUserDetails) {
+
+        AssetResponse.AssetsOutDTO assetsOutDTO =
+                assetService.getAssetListBySubCategoryService(categoryName, subCategoryName, pageable, myUserDetails);
+        ResponseDTO<?> responseDTO = new ResponseDTO<>(assetsOutDTO);
+        return ResponseEntity.ok().body(responseDTO);
+    }
 }

--- a/src/main/java/com/phoenix/assetbe/service/AssetService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AssetService.java
@@ -70,6 +70,20 @@ public class AssetService {
         return new AssetResponse.AssetsOutDTO(assetDetailList);
     }
 
+    public AssetResponse.AssetsOutDTO getAssetListBySubCategoryService(String categoryName, String subCategoryName,
+                                                                       Pageable pageable, MyUserDetails myUserDetails) {
+        Page<AssetResponse.AssetsOutDTO.AssetDetail> assetDetailList;
+        if(myUserDetails != null) {
+            Long userId = myUserDetails.getUser().getId();
+            assetDetailList = assetQueryRepository
+                    .findAssetListWithUserIdAndPaginationBySubCategory(userId, categoryName, subCategoryName, pageable);
+        }else {
+            assetDetailList = assetQueryRepository
+                    .findAssetListWithPaginationBySubCategory(categoryName, subCategoryName, pageable);
+        }
+        return new AssetResponse.AssetsOutDTO(assetDetailList);
+    }
+
     public Asset findAssetById(Long assetId){
         Asset assetPS = assetRepository.findById(assetId).orElseThrow(
                 () -> new Exception400("id", "존재하지 않는 에셋입니다. "));

--- a/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
@@ -127,8 +127,8 @@ public class AssetControllerTest {
         tagRepository.saveAll(Arrays.asList(t1, t2, t3, t4, t5, t6));
 
         AssetCategory ac1 = AssetCategory.builder().asset(a1).category(c1).build();
-        AssetCategory ac2 = AssetCategory.builder().asset(a2).category(c2).build();
-        AssetCategory ac3 = AssetCategory.builder().asset(a3).category(c3).build();
+        AssetCategory ac2 = AssetCategory.builder().asset(a2).category(c1).build();
+        AssetCategory ac3 = AssetCategory.builder().asset(a3).category(c1).build();
         AssetCategory ac4 = AssetCategory.builder().asset(a4).category(c1).build();
         AssetCategory ac5 = AssetCategory.builder().asset(a5).category(c2).build();
         AssetCategory ac6 = AssetCategory.builder().asset(a6).category(c3).build();
@@ -309,6 +309,53 @@ public class AssetControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
                 .get("/assets/{categoryName}",categoryName)
+                .param("page", page)
+                .param("size", size));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200));
+    }
+
+    @DisplayName("하위 카테고리별 에셋 조회 로그인 성공")
+    @WithUserDetails(value = "user1@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void find_asset_list_with_user_id_and_pagination_by_sub_category_test() throws Exception {
+        // given
+        String categoryName = "A";
+        String subCategoryName = "AA";
+        String page = "0";
+        String size = "4";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .get("/assets/{categoryName}/{subCategoryName}", categoryName, subCategoryName)
+                .param("page", page)
+                .param("size", size));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200));
+    }
+
+    @DisplayName("하위 카테고리별 에셋 조회 비로그인 성공")
+    @Test
+    public void find_asset_list_with_pagination_by_sub_category_test() throws Exception {
+        // given
+        String categoryName = "A";
+        String subCategoryName = "AA";
+        String page = "0";
+        String size = "4";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .get("/assets/{categoryName}/{subCategoryName}", categoryName, subCategoryName)
                 .param("page", page)
                 .param("size", size));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();


### PR DESCRIPTION
## Motivation

- 하위 카테고리별 에셋을 조회한다

resolved #24 

## Proposed Changes

- 비로그인 사용자와 로그인 사용자를 구분한다.
- 하위 카테고리별 에셋 조회를 구현한다.
- 상위 카테고리 이름과 하위 카테고리 이름을 받아 조회한다.
- 로그인 사용자이면 에셋에 찜한 상태, 장바구니 상태를 포함시킨다.
- 정렬 : 에셋 릴리즈날짜 기준 내림차순
- 페이지네이션 : 기본 page=0 & size=28