### PR TITLE
feat : #35 카테고리 에셋 카운트 - count 하는 방법 수정

### DIFF
--- a/src/main/java/com/phoenix/assetbe/controller/AssetController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/AssetController.java
@@ -26,11 +26,11 @@ public class AssetController {
     private final AssetService assetService;
 
     @GetMapping("/assets")
-    public ResponseEntity<?> getAssets(@PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
+    public ResponseEntity<?> getAssetList(@PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
                                        @AuthenticationPrincipal MyUserDetails myUserDetails) {
 
-        AssetResponse.AssetsOutDTO assetsOutDTO = assetService.getAssetsService(pageable, myUserDetails);
-        ResponseDTO<?> responseDTO = new ResponseDTO<>(assetsOutDTO);
+        AssetResponse.AssetListOutDTO assetListOutDTO = assetService.getAssetListService(pageable, myUserDetails);
+        ResponseDTO<?> responseDTO = new ResponseDTO<>(assetListOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
 
@@ -50,9 +50,9 @@ public class AssetController {
             @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal MyUserDetails myUserDetails) {
 
-        AssetResponse.AssetsOutDTO assetsOutDTO =
+        AssetResponse.AssetListOutDTO assetListOutDTO =
                 assetService.getAssetListByCategoryService(categoryName, pageable, myUserDetails);
-        ResponseDTO<?> responseDTO = new ResponseDTO<>(assetsOutDTO);
+        ResponseDTO<?> responseDTO = new ResponseDTO<>(assetListOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
 
@@ -63,9 +63,9 @@ public class AssetController {
             @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal MyUserDetails myUserDetails) {
 
-        AssetResponse.AssetsOutDTO assetsOutDTO =
+        AssetResponse.AssetListOutDTO assetListOutDTO =
                 assetService.getAssetListBySubCategoryService(categoryName, subCategoryName, pageable, myUserDetails);
-        ResponseDTO<?> responseDTO = new ResponseDTO<>(assetsOutDTO);
+        ResponseDTO<?> responseDTO = new ResponseDTO<>(assetListOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
 }

--- a/src/main/java/com/phoenix/assetbe/controller/AssetController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/AssetController.java
@@ -10,10 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,15 +22,22 @@ public class AssetController {
 
     private final AssetService assetService;
 
+    /**
+     * 개별 에셋
+     */
     @GetMapping("/assets")
-    public ResponseEntity<?> getAssetList(@PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
-                                       @AuthenticationPrincipal MyUserDetails myUserDetails) {
+    public ResponseEntity<?> getAssetList(
+            @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal MyUserDetails myUserDetails) {
 
         AssetResponse.AssetListOutDTO assetListOutDTO = assetService.getAssetListService(pageable, myUserDetails);
         ResponseDTO<?> responseDTO = new ResponseDTO<>(assetListOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
 
+    /**
+     * 에셋 상세
+     */
     @GetMapping("/assets/{id}/details")
     public ResponseEntity<?> getAssetDetails(@PathVariable Long id,
                                              @AuthenticationPrincipal MyUserDetails myUserDetails) {
@@ -44,6 +48,9 @@ public class AssetController {
         return ResponseEntity.ok().body(responseDTO);
     }
 
+    /**
+     * 카테고리별 에셋
+     */
     @GetMapping("/assets/{categoryName}")
     public ResponseEntity<?> getAssetListByCategory(
             @PathVariable String categoryName,
@@ -56,6 +63,10 @@ public class AssetController {
         return ResponseEntity.ok().body(responseDTO);
     }
 
+    /**
+     * 카테고리별
+     * 하위카테고리별 에셋
+     */
     @GetMapping("/assets/{categoryName}/{subCategoryName}")
     public ResponseEntity<?> getAssetListBySubCategory(
             @PathVariable String categoryName,

--- a/src/main/java/com/phoenix/assetbe/controller/CategoryController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/CategoryController.java
@@ -2,6 +2,7 @@ package com.phoenix.assetbe.controller;
 
 import com.phoenix.assetbe.dto.ResponseDTO;
 import com.phoenix.assetbe.dto.asset.AssetResponse;
+import com.phoenix.assetbe.dto.asset.CategoryResponse;
 import com.phoenix.assetbe.service.CategoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +19,7 @@ public class CategoryController {
 
     @GetMapping("/assets/count")
     public ResponseEntity<?> getCategoryList() {
-        AssetResponse.CategoryOutDTO categoryOutDTO = categoryService.getCategoryListService();
+        CategoryResponse.CategoryOutDTO categoryOutDTO = categoryService.getCategoryListService();
         ResponseDTO<?> responseDTO = new ResponseDTO<>(categoryOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }

--- a/src/main/java/com/phoenix/assetbe/controller/ReviewController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/ReviewController.java
@@ -22,8 +22,8 @@ public class ReviewController {
     public ResponseEntity<?> getReviews(@PathVariable Long id,
                                         @AuthenticationPrincipal MyUserDetails myUserDetails) {
 
-        ReviewResponse.ReviewsOutDTO reviewsOutDTO = reviewService.getReviewsService(id, myUserDetails);
-        ResponseDTO<?> responseDTO = new ResponseDTO<>(reviewsOutDTO);
+        ReviewResponse.ReviewListOutDTO reviewListOutDTO = reviewService.getReviewsService(id, myUserDetails);
+        ResponseDTO<?> responseDTO = new ResponseDTO<>(reviewListOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
 

--- a/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
@@ -77,6 +77,7 @@ public class AssetResponse {
             private Integer discount;
             private Double discountPrice;
             private LocalDate releaseDate;
+            private String thumbnailUrl;
             private Double rating;
             private Long reviewCount;
             private Long wishCount;
@@ -85,7 +86,7 @@ public class AssetResponse {
 
             public AssetDetail(Long assetId, String assetName, Double price,
                                Integer discount, Double discountPrice,
-                               LocalDate releaseDate, Double rating, Long reviewCount,
+                               LocalDate releaseDate, String thumbnailUrl, Double rating, Long reviewCount,
                                Long wishCount) {
                 this.assetId = assetId;
                 this.assetName = assetName;
@@ -93,6 +94,7 @@ public class AssetResponse {
                 this.discount = discount;
                 this.discountPrice = discountPrice;
                 this.releaseDate = releaseDate;
+                this.thumbnailUrl = thumbnailUrl;
                 this.rating = rating;
                 this.reviewCount = reviewCount;
                 this.wishCount = wishCount;

--- a/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
@@ -29,9 +29,10 @@ public class AssetResponse {
         private Long wishCount;
         private Long visitCount;
         private Long wishlistId;
+        private List<?> previewList;
         private List<String> tagList;
 
-        public AssetDetailsOutDTO(Asset asset, Long wishlistId, List<String> tagList) {
+        public AssetDetailsOutDTO(Asset asset, Long wishlistId, List<?> previewList, List<String> tagList) {
             this.assetId = asset.getId();
             this.assetName = asset.getAssetName();
             this.price = asset.getPrice();
@@ -45,6 +46,7 @@ public class AssetResponse {
             this.wishCount = asset.getWishCount();
             this.visitCount = asset.getVisitCount();
             this.wishlistId = wishlistId;
+            this.previewList = previewList;
             this.tagList = tagList;
         }
     }
@@ -70,7 +72,7 @@ public class AssetResponse {
         @NoArgsConstructor
         @AllArgsConstructor
         @Getter @Setter
-        public static class AssetDetail {
+        public static class AssetOutDTO {
             private Long assetId;
             private String assetName;
             private Double price;
@@ -84,7 +86,7 @@ public class AssetResponse {
             private Long wishlistId;
             private Long cartId;
 
-            public AssetDetail(Long assetId, String assetName, Double price,
+            public AssetOutDTO(Long assetId, String assetName, Double price,
                                Integer discount, Double discountPrice,
                                LocalDate releaseDate, String thumbnailUrl, Double rating, Long reviewCount,
                                Long wishCount) {

--- a/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
@@ -1,7 +1,9 @@
 package com.phoenix.assetbe.dto.asset;
 
 import com.phoenix.assetbe.model.asset.Asset;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.domain.Page;
 
@@ -10,47 +12,12 @@ import java.util.List;
 
 public class AssetResponse {
 
-    @Getter @Setter
-    public static class CategoryOutDTO {
 
-        private List<AssetResponse.CategoryOutDTO.CategoryDTO> categoryList;
 
-        public CategoryOutDTO(List<AssetResponse.CategoryOutDTO.CategoryDTO> categoryList) {
-            this.categoryList = categoryList;
-        }
-
-        @Getter
-        @Setter
-        public static class CategoryDTO {
-            private String categoryName;
-            private Long categoryCount;
-            private List<String> tagList;
-            private List<SubCategoryDTO> subCategoryList;
-
-            public CategoryDTO(String categoryName, Long categoryCount, List<String> tagList, List<SubCategoryDTO> subCategoryList) {
-                this.categoryName = categoryName;
-                this.categoryCount = categoryCount;
-                this.tagList = tagList;
-                this.subCategoryList = subCategoryList;
-            }
-        }
-
-        @Getter
-        @Setter
-        public static class SubCategoryDTO {
-            private String subCategoryName;
-            private Long subCategoryCount;
-            private List<String> tagList;
-
-            public SubCategoryDTO(String subCategoryName, Long subCategoryCount, List<String> tagList) {
-                this.subCategoryName = subCategoryName;
-                this.subCategoryCount = subCategoryCount;
-                this.tagList = tagList;
-            }
-        }
-    }
-
-    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Setter
     public static class AssetDetailsOutDTO {
         private Long assetId;
         private String assetName;
@@ -81,7 +48,10 @@ public class AssetResponse {
         }
     }
 
-    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Setter
     public static class AssetsOutDTO {
         private List<?> assetList;
         private int size;
@@ -97,6 +67,7 @@ public class AssetResponse {
             this.totalElement = assetList.getTotalElements();
         }
 
+        @NoArgsConstructor
         @Getter
         @Setter
         public static class AssetDetail {

--- a/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
@@ -29,10 +29,10 @@ public class AssetResponse {
         private Long wishCount;
         private Long visitCount;
         private Long wishlistId;
-        private List<?> previewList;
+        private List<String> previewList;
         private List<String> tagList;
 
-        public AssetDetailsOutDTO(Asset asset, Long wishlistId, List<?> previewList, List<String> tagList) {
+        public AssetDetailsOutDTO(Asset asset, Long wishlistId, List<String> previewList, List<String> tagList) {
             this.assetId = asset.getId();
             this.assetName = asset.getAssetName();
             this.price = asset.getPrice();

--- a/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
@@ -14,12 +14,13 @@ public class AssetResponse {
 
     @NoArgsConstructor
     @AllArgsConstructor
-    @Getter
-    @Setter
+    @Getter @Setter
     public static class AssetDetailsOutDTO {
         private Long assetId;
         private String assetName;
         private Double price;
+        private Integer discount;
+        private Double discountPrice;
         private Double fileSize;
         private String fileUrl;
         private String creator;
@@ -34,6 +35,8 @@ public class AssetResponse {
             this.assetId = asset.getId();
             this.assetName = asset.getAssetName();
             this.price = asset.getPrice();
+            this.discount = asset.getDiscount();
+            this.discountPrice = asset.getDiscountPrice();
             this.fileSize = asset.getSize();
             this.fileUrl = asset.getFileUrl();
             this.creator = asset.getCreator();
@@ -48,16 +51,15 @@ public class AssetResponse {
 
     @NoArgsConstructor
     @AllArgsConstructor
-    @Getter
-    @Setter
-    public static class AssetsOutDTO {
+    @Getter @Setter
+    public static class AssetListOutDTO {
         private List<?> assetList;
         private int size;
         private int currentPage;
         private int totalPage;
         private long totalElement;
 
-        public AssetsOutDTO(Page<?> assetList) {
+        public AssetListOutDTO(Page<?> assetList) {
             this.assetList = assetList.getContent();
             this.size = assetList.getSize();
             this.currentPage = assetList.getPageable().getPageNumber();
@@ -66,12 +68,14 @@ public class AssetResponse {
         }
 
         @NoArgsConstructor
-        @Getter
-        @Setter
+        @AllArgsConstructor
+        @Getter @Setter
         public static class AssetDetail {
             private Long assetId;
             private String assetName;
             private Double price;
+            private Integer discount;
+            private Double discountPrice;
             private LocalDate releaseDate;
             private Double rating;
             private Long reviewCount;
@@ -80,29 +84,18 @@ public class AssetResponse {
             private Long cartId;
 
             public AssetDetail(Long assetId, String assetName, Double price,
+                               Integer discount, Double discountPrice,
                                LocalDate releaseDate, Double rating, Long reviewCount,
                                Long wishCount) {
                 this.assetId = assetId;
                 this.assetName = assetName;
                 this.price = price;
+                this.discount = discount;
+                this.discountPrice = discountPrice;
                 this.releaseDate = releaseDate;
                 this.rating = rating;
                 this.reviewCount = reviewCount;
                 this.wishCount = wishCount;
-            }
-
-            public AssetDetail(Long assetId, String assetName, Double price,
-                               LocalDate releaseDate, Double rating, Long reviewCount,
-                               Long wishCount, Long wishlistId, Long cartId) {
-                this.assetId = assetId;
-                this.assetName = assetName;
-                this.price = price;
-                this.releaseDate = releaseDate;
-                this.rating = rating;
-                this.reviewCount = reviewCount;
-                this.wishCount = wishCount;
-                this.wishlistId = wishlistId;
-                this.cartId = cartId;
             }
         }
     }

--- a/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
@@ -12,8 +12,6 @@ import java.util.List;
 
 public class AssetResponse {
 
-
-
     @NoArgsConstructor
     @AllArgsConstructor
     @Getter

--- a/src/main/java/com/phoenix/assetbe/dto/asset/CategoryResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/CategoryResponse.java
@@ -1,0 +1,64 @@
+package com.phoenix.assetbe.dto.asset;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+public class CategoryResponse {
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter @Setter
+    public static class CategoryOutDTO {
+
+        private List<CategoryResponse.CategoryOutDTO.CategoryDTO> categoryList;
+
+        @AllArgsConstructor
+        @NoArgsConstructor
+        @Getter @Setter
+        public static class CategoryDTO {
+            private String categoryName;
+            private Long categoryCount;
+            private List<String> tagList;
+            private List<SubCategoryDTO> subCategoryList;
+        }
+
+        @AllArgsConstructor
+        @NoArgsConstructor
+        @Getter @Setter
+        public static class CountByCategory {
+            private String categoryName;
+            private Long categoryCount;
+        }
+
+        @AllArgsConstructor
+        @NoArgsConstructor
+        @Getter @Setter
+        public static class SubCategoryDTO {
+            private String subCategoryName;
+            private Long subCategoryCount;
+            private List<String> tagList;
+        }
+
+        @AllArgsConstructor
+        @NoArgsConstructor
+        @Getter @Setter
+        public static class CountBySubCategory {
+            private String categoryName;
+            private String subCategoryName;
+            private Long subCategoryCount;
+        }
+
+        @AllArgsConstructor
+        @NoArgsConstructor
+        @Getter @Setter
+        public static class CountByTag {
+            private String categoryName;
+            private String subCategoryName;
+            private String tagName;
+            private Long tagCount;
+        }
+    }
+}

--- a/src/main/java/com/phoenix/assetbe/dto/asset/ReviewRequest.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/ReviewRequest.java
@@ -1,33 +1,25 @@
 package com.phoenix.assetbe.dto.asset;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class ReviewRequest {
 
-    @Getter @Setter
+    @AllArgsConstructor
     @NoArgsConstructor
+    @Getter @Setter
     public static class ReviewInDTO {
         private Long userId;
         private Double rating;
         private String content;
-
-        public ReviewInDTO(Long userId, Double rating, String content) {
-            this.userId = userId;
-            this.rating = rating;
-            this.content = content;
-        }
     }
 
+    @AllArgsConstructor
+    @NoArgsConstructor
     @Getter @Setter
     public static class DeleteReviewInDTO {
         private Long userId;
-
-        public DeleteReviewInDTO(){}
-
-        public DeleteReviewInDTO(Long userId) {
-            this.userId = userId;
-        }
     }
 }

--- a/src/main/java/com/phoenix/assetbe/dto/asset/ReviewResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/ReviewResponse.java
@@ -1,29 +1,25 @@
 package com.phoenix.assetbe.dto.asset;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public class ReviewResponse {
 
-    @Getter
-    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter @Setter
     public static class ReviewsOutDTO {
         private boolean hasAsset;
         private boolean hasReview;
         private boolean hasWishlist;
         private List<Reviews> reviewList;
 
-        public ReviewsOutDTO(boolean hasAsset, boolean hasReview, boolean hasWishlist, List<Reviews> reviewList) {
-            this.hasAsset = hasAsset;
-            this.hasReview = hasReview;
-            this.hasWishlist = hasWishlist;
-            this.reviewList = reviewList;
-        }
-
+        @AllArgsConstructor
+        @NoArgsConstructor
         @Getter @Setter
         public static class Reviews {
             private Long reviewId;
@@ -32,19 +28,11 @@ public class ReviewResponse {
             private Long userId;
             private String firstName;
             private String lastName;
-
-            public Reviews(Long reviewId, Double rating, String content,
-                           Long userId, String firstName, String lastName) {
-                this.reviewId = reviewId;
-                this.rating = rating;
-                this.content = content;
-                this.userId = userId;
-                this.firstName = firstName;
-                this.lastName = lastName;
-            }
         }
     }
 
+    @AllArgsConstructor
+    @NoArgsConstructor
     @Getter @Setter
     public static class ReviewOutDTO {
         private Long userId;
@@ -53,14 +41,5 @@ public class ReviewResponse {
         private String content;
         private Double reviewRating;
         private Double assetRating;
-
-        public ReviewOutDTO(Long userId, Long assetId, Long reviewId, String content, Double reviewRating, Double assetRating) {
-            this.userId = userId;
-            this.assetId = assetId;
-            this.reviewId = reviewId;
-            this.content = content;
-            this.reviewRating = reviewRating;
-            this.assetRating = assetRating;
-        }
     }
 }

--- a/src/main/java/com/phoenix/assetbe/dto/asset/ReviewResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/ReviewResponse.java
@@ -12,16 +12,16 @@ public class ReviewResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter @Setter
-    public static class ReviewsOutDTO {
+    public static class ReviewListOutDTO {
         private boolean hasAsset;
         private boolean hasReview;
         private boolean hasWishlist;
-        private List<Reviews> reviewList;
+        private List<ReviewOutDTO> reviewList;
 
         @AllArgsConstructor
         @NoArgsConstructor
         @Getter @Setter
-        public static class Reviews {
+        public static class ReviewOutDTO {
             private Long reviewId;
             private Double rating;
             private String content;

--- a/src/main/java/com/phoenix/assetbe/model/asset/Asset.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/Asset.java
@@ -95,4 +95,9 @@ public class Asset extends MyTimeBaseUtil {
         this.rating = (double) Math.round(reviewRatingSum * 10 / (asset.getReviewCount() - 1)) / 10;
         this.reviewCount = asset.getReviewCount() - 1;
     }
+
+    public void calculateRatingOnDeleteReview(Asset asset){
+        this.rating = 0D;
+        this.reviewCount = asset.getReviewCount() - 1;
+    }
 }

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.phoenix.assetbe.model.asset.QAsset.asset;
 import static com.phoenix.assetbe.model.asset.QAssetCategory.assetCategory;
@@ -25,11 +26,12 @@ import static com.phoenix.assetbe.model.wish.QWishList.wishList;
 @RequiredArgsConstructor
 @Repository
 public class AssetQueryRepository {
+
     private final JPAQueryFactory queryFactory;
 
-    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithUserIdAndPaging(Long userId, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
-                .select(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithUserIdAndPaging(Long userId, Pageable pageable){
+        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
+                .select(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
                         asset.id,
                         asset.assetName,
                         asset.price,
@@ -46,6 +48,7 @@ public class AssetQueryRepository {
                 .from(asset)
                 .leftJoin(wishList).on(wishList.asset.id.eq(asset.id)).on(wishList.user.id.eq(userId))
                 .leftJoin(cart).on(cart.asset.id.eq(asset.id)).on(cart.user.id.eq(userId))
+                .where(asset.status.eq(true))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(assetSort(pageable))
@@ -53,14 +56,15 @@ public class AssetQueryRepository {
 
         Long totalCount = queryFactory.select(asset.id.countDistinct())
                 .from(asset)
+                .where(asset.status.eq(true))
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, totalCount);
     }
 
-    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithPaging(Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
-                .select(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithPaging(Pageable pageable){
+        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
+                .select(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
                         asset.id,
                         asset.assetName,
                         asset.price,
@@ -73,6 +77,7 @@ public class AssetQueryRepository {
                         asset.wishCount)
                 )
                 .from(asset)
+                .where(asset.status.eq(true))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(assetSort(pageable))
@@ -80,15 +85,16 @@ public class AssetQueryRepository {
 
         Long totalCount = queryFactory.select(asset.id.countDistinct())
                 .from(asset)
+                .where(asset.status.eq(true))
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, totalCount);
     }
 
-    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithUserIdAndPaginationByCategory(
+    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithUserIdAndPaginationByCategory(
             Long userId, String categoryName, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
+                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
                         asset.id,
                         asset.assetName,
                         asset.price,
@@ -107,7 +113,7 @@ public class AssetQueryRepository {
                 .innerJoin(category).on(assetCategory.category.eq(category))
                 .leftJoin(wishList).on(wishList.asset.eq(asset)).on(wishList.user.id.eq(userId))
                 .leftJoin(cart).on(cart.asset.eq(asset)).on(cart.user.id.eq(userId))
-                .where(category.categoryName.eq(categoryName))
+                .where(category.categoryName.eq(categoryName).and(asset.status.eq(true)))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(assetSort(pageable))
@@ -117,17 +123,17 @@ public class AssetQueryRepository {
                 .from(asset)
                 .innerJoin(assetCategory).on(assetCategory.asset.eq(asset))
                 .innerJoin(category).on(category.eq(assetCategory.category))
-                .where(category.categoryName.eq(categoryName))
+                .where(category.categoryName.eq(categoryName).and(asset.status.eq(true)))
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, totalCount);
 
     }
 
-    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithPaginationByCategory(
+    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithPaginationByCategory(
             String categoryName, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
+                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
                         asset.id,
                         asset.assetName,
                         asset.price,
@@ -142,7 +148,7 @@ public class AssetQueryRepository {
                 .from(asset)
                 .innerJoin(assetCategory).on(assetCategory.asset.eq(asset))
                 .innerJoin(category).on(assetCategory.category.eq(category))
-                .where(category.categoryName.eq(categoryName))
+                .where(category.categoryName.eq(categoryName).and(asset.status.eq(true)))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(assetSort(pageable))
@@ -152,17 +158,17 @@ public class AssetQueryRepository {
                 .from(asset)
                 .innerJoin(assetCategory).on(assetCategory.asset.eq(asset))
                 .innerJoin(category).on(category.eq(assetCategory.category))
-                .where(category.categoryName.eq(categoryName))
+                .where(category.categoryName.eq(categoryName).and(asset.status.eq(true)))
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, totalCount);
 
     }
 
-    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithUserIdAndPaginationBySubCategory(
+    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithUserIdAndPaginationBySubCategory(
             Long userId, String categoryName, String subCategoryName, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
+                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
                         asset.id,
                         asset.assetName,
                         asset.price,
@@ -182,6 +188,7 @@ public class AssetQueryRepository {
                 .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id).and(subCategory.subCategoryName.eq(subCategoryName)))
                 .leftJoin(wishList).on(wishList.user.id.eq(userId).and(wishList.asset.eq(asset)))
                 .leftJoin(cart).on(cart.user.id.eq(userId).and(cart.asset.eq(asset)))
+                .where(asset.status.eq(true))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(assetSort(pageable))
@@ -192,16 +199,17 @@ public class AssetQueryRepository {
                 .innerJoin(assetTag).on(asset.eq(assetTag.asset))
                 .innerJoin(category).on(category.id.eq(assetTag.category.id).and(category.categoryName.eq(categoryName)))
                 .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id).and(subCategory.subCategoryName.eq(subCategoryName)))
+                .where(asset.status.eq(true))
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, totalCount);
 
     }
 
-    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithPaginationBySubCategory(
+    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithPaginationBySubCategory(
             String categoryName, String subCategoryName, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
+                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
                         asset.id,
                         asset.assetName,
                         asset.price,
@@ -217,6 +225,7 @@ public class AssetQueryRepository {
                 .innerJoin(assetTag).on(asset.eq(assetTag.asset))
                 .innerJoin(category).on(category.id.eq(assetTag.category.id).and(category.categoryName.eq(categoryName)))
                 .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id).and(subCategory.subCategoryName.eq(subCategoryName)))
+                .where(asset.status.eq(true))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(assetSort(pageable))
@@ -227,10 +236,23 @@ public class AssetQueryRepository {
                 .innerJoin(assetTag).on(asset.eq(assetTag.asset))
                 .innerJoin(category).on(category.id.eq(assetTag.category.id).and(category.categoryName.eq(categoryName)))
                 .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id).and(subCategory.subCategoryName.eq(subCategoryName)))
+                .where(asset.status.eq(true))
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, totalCount);
 
+    }
+
+    public Optional<Asset> findById(Long userId) {
+        return Optional.ofNullable(queryFactory.selectFrom(asset)
+                .where(asset.status.eq(true).and(asset.id.eq(userId)))
+                .fetchOne());
+    }
+
+    public List<Asset> findAllById(List<Long> userIds) {
+        return queryFactory.selectFrom(asset)
+                .where(asset.status.eq(true).and(asset.id.eq(userIds)))
+                .fetch();
     }
 
     /**

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
@@ -1,7 +1,6 @@
 package com.phoenix.assetbe.model.asset;
 
 import com.phoenix.assetbe.dto.asset.AssetResponse;
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -250,17 +249,13 @@ public class AssetQueryRepository {
                 .fetchOne());
     }
 
-    public List<Asset> findAllById(List<Long> userIds) {
-
-        BooleanBuilder builder = new BooleanBuilder();
-        builder.and(asset.status.eq(true));
-        for(Long userId : userIds) {
-            builder.or(asset.id.eq(userId));
-        }
-
-        return queryFactory.selectFrom(asset)
-                .where(builder)
-                .fetch();
+    public boolean existsAssetByAssetId(Long assetId) {
+        Integer fetchOne = queryFactory
+                .selectOne()
+                .from(asset)
+                .where(asset.status.eq(true).and(asset.id.eq(assetId)))
+                .fetchFirst(); // limit 1
+        return fetchOne != null; // 1개가 있는지 없는지 판단 (없으면 null 이므로 null 체크)
     }
 
     /**

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
@@ -16,7 +16,6 @@ import java.util.List;
 
 import static com.phoenix.assetbe.model.asset.QAsset.asset;
 import static com.phoenix.assetbe.model.asset.QAssetCategory.assetCategory;
-import static com.phoenix.assetbe.model.asset.QAssetSubCategory.assetSubCategory;
 import static com.phoenix.assetbe.model.asset.QAssetTag.assetTag;
 import static com.phoenix.assetbe.model.asset.QCategory.category;
 import static com.phoenix.assetbe.model.asset.QSubCategory.subCategory;
@@ -28,11 +27,21 @@ import static com.phoenix.assetbe.model.wish.QWishList.wishList;
 public class AssetQueryRepository {
     private final JPAQueryFactory queryFactory;
 
-    public Page<AssetResponse.AssetsOutDTO.AssetDetail> findAssetsWithUserIdAndPaging(Long userId, Pageable pageable){
-        List <AssetResponse.AssetsOutDTO.AssetDetail> result = queryFactory
-                .select(Projections.constructor(AssetResponse.AssetsOutDTO.AssetDetail.class,
-                        asset.id, asset.assetName, asset.price, asset.releaseDate, asset.rating, asset.reviewCount,
-                        asset.wishCount, wishList.id, cart.id))
+    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithUserIdAndPaging(Long userId, Pageable pageable){
+        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
+                .select(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+                        asset.id,
+                        asset.assetName,
+                        asset.price,
+                        asset.discount,
+                        asset.discountPrice,
+                        asset.releaseDate,
+                        asset.rating,
+                        asset.reviewCount,
+                        asset.wishCount,
+                        wishList.id,
+                        cart.id)
+                )
                 .from(asset)
                 .leftJoin(wishList).on(wishList.asset.id.eq(asset.id)).on(wishList.user.id.eq(userId))
                 .leftJoin(cart).on(cart.asset.id.eq(asset.id)).on(cart.user.id.eq(userId))
@@ -41,38 +50,55 @@ public class AssetQueryRepository {
                 .orderBy(assetSort(pageable))
                 .fetch();
 
-        Long totalCount = queryFactory.select(asset.count())
+        Long totalCount = queryFactory.select(asset.id.countDistinct())
                 .from(asset)
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, totalCount);
     }
 
-    public Page<AssetResponse.AssetsOutDTO.AssetDetail> findAssetsWithPaging(Pageable pageable){
-        List <AssetResponse.AssetsOutDTO.AssetDetail> result = queryFactory
-                .select(Projections.constructor(AssetResponse.AssetsOutDTO.AssetDetail.class,
-                        asset.id, asset.assetName, asset.price, asset.releaseDate, asset.rating, asset.reviewCount,
-                        asset.wishCount))
+    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithPaging(Pageable pageable){
+        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
+                .select(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+                        asset.id,
+                        asset.assetName,
+                        asset.price,
+                        asset.discount,
+                        asset.discountPrice,
+                        asset.releaseDate,
+                        asset.rating,
+                        asset.reviewCount,
+                        asset.wishCount)
+                )
                 .from(asset)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(assetSort(pageable))
                 .fetch();
 
-        Long totalCount = queryFactory.select(asset.count())
+        Long totalCount = queryFactory.select(asset.id.countDistinct())
                 .from(asset)
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, totalCount);
     }
 
-    public Page<AssetResponse.AssetsOutDTO.AssetDetail> findAssetListWithUserIdAndPaginationByCategory(
+    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithUserIdAndPaginationByCategory(
             Long userId, String categoryName, Pageable pageable){
-        List <AssetResponse.AssetsOutDTO.AssetDetail> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetsOutDTO.AssetDetail.class,
-                        asset.id, asset.assetName, asset.price,
-                        asset.releaseDate, asset.rating, asset.reviewCount,
-                        asset.wishCount, wishList.id, cart.id))
+        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
+                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+                        asset.id,
+                        asset.assetName,
+                        asset.price,
+                        asset.discount,
+                        asset.discountPrice,
+                        asset.releaseDate,
+                        asset.rating,
+                        asset.reviewCount,
+                        asset.wishCount,
+                        wishList.id,
+                        cart.id)
+                )
                 .from(asset)
                 .innerJoin(assetCategory).on(assetCategory.asset.eq(asset))
                 .innerJoin(category).on(assetCategory.category.eq(category))
@@ -84,7 +110,7 @@ public class AssetQueryRepository {
                 .orderBy(assetSort(pageable))
                 .fetch();
 
-        Long totalCount = queryFactory.select(asset.count())
+        Long totalCount = queryFactory.select(asset.id.countDistinct())
                 .from(asset)
                 .innerJoin(assetCategory).on(assetCategory.asset.eq(asset))
                 .innerJoin(category).on(category.eq(assetCategory.category))
@@ -95,13 +121,20 @@ public class AssetQueryRepository {
 
     }
 
-    public Page<AssetResponse.AssetsOutDTO.AssetDetail> findAssetListWithPaginationByCategory(
+    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithPaginationByCategory(
             String categoryName, Pageable pageable){
-        List <AssetResponse.AssetsOutDTO.AssetDetail> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetsOutDTO.AssetDetail.class,
-                        asset.id, asset.assetName, asset.price,
-                        asset.releaseDate, asset.rating, asset.reviewCount,
-                        asset.wishCount))
+        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
+                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+                        asset.id,
+                        asset.assetName,
+                        asset.price,
+                        asset.discount,
+                        asset.discountPrice,
+                        asset.releaseDate,
+                        asset.rating,
+                        asset.reviewCount,
+                        asset.wishCount)
+                )
                 .from(asset)
                 .innerJoin(assetCategory).on(assetCategory.asset.eq(asset))
                 .innerJoin(category).on(assetCategory.category.eq(category))
@@ -111,7 +144,7 @@ public class AssetQueryRepository {
                 .orderBy(assetSort(pageable))
                 .fetch();
 
-        Long totalCount = queryFactory.select(asset.count())
+        Long totalCount = queryFactory.select(asset.id.countDistinct())
                 .from(asset)
                 .innerJoin(assetCategory).on(assetCategory.asset.eq(asset))
                 .innerJoin(category).on(category.eq(assetCategory.category))
@@ -122,13 +155,22 @@ public class AssetQueryRepository {
 
     }
 
-    public Page<AssetResponse.AssetsOutDTO.AssetDetail> findAssetListWithUserIdAndPaginationBySubCategory(
+    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithUserIdAndPaginationBySubCategory(
             Long userId, String categoryName, String subCategoryName, Pageable pageable){
-        List <AssetResponse.AssetsOutDTO.AssetDetail> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetsOutDTO.AssetDetail.class,
-                        asset.id, asset.assetName, asset.price,
-                        asset.releaseDate, asset.rating, asset.reviewCount,
-                        asset.wishCount, wishList.id, cart.id))
+        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
+                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+                        asset.id,
+                        asset.assetName,
+                        asset.price,
+                        asset.discount,
+                        asset.discountPrice,
+                        asset.releaseDate,
+                        asset.rating,
+                        asset.reviewCount,
+                        asset.wishCount,
+                        wishList.id,
+                        cart.id)
+                )
                 .from(asset)
                 .innerJoin(assetTag).on(asset.eq(assetTag.asset))
                 .innerJoin(category).on(category.id.eq(assetTag.category.id).and(category.categoryName.eq(categoryName)))
@@ -140,7 +182,7 @@ public class AssetQueryRepository {
                 .orderBy(assetSort(pageable))
                 .fetch();
 
-        Long totalCount = queryFactory.select(asset.count())
+        Long totalCount = queryFactory.select(asset.id.countDistinct())
                 .from(asset)
                 .innerJoin(assetTag).on(asset.eq(assetTag.asset))
                 .innerJoin(category).on(category.id.eq(assetTag.category.id).and(category.categoryName.eq(categoryName)))
@@ -151,13 +193,20 @@ public class AssetQueryRepository {
 
     }
 
-    public Page<AssetResponse.AssetsOutDTO.AssetDetail> findAssetListWithPaginationBySubCategory(
+    public Page<AssetResponse.AssetListOutDTO.AssetDetail> findAssetListWithPaginationBySubCategory(
             String categoryName, String subCategoryName, Pageable pageable){
-        List <AssetResponse.AssetsOutDTO.AssetDetail> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetsOutDTO.AssetDetail.class,
-                        asset.id, asset.assetName, asset.price,
-                        asset.releaseDate, asset.rating, asset.reviewCount,
-                        asset.wishCount))
+        List <AssetResponse.AssetListOutDTO.AssetDetail> result = queryFactory
+                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetDetail.class,
+                        asset.id,
+                        asset.assetName,
+                        asset.price,
+                        asset.discount,
+                        asset.discountPrice,
+                        asset.releaseDate,
+                        asset.rating,
+                        asset.reviewCount,
+                        asset.wishCount)
+                )
                 .from(asset)
                 .innerJoin(assetTag).on(asset.eq(assetTag.asset))
                 .innerJoin(category).on(category.id.eq(assetTag.category.id).and(category.categoryName.eq(categoryName)))
@@ -167,7 +216,7 @@ public class AssetQueryRepository {
                 .orderBy(assetSort(pageable))
                 .fetch();
 
-        Long totalCount = queryFactory.select(asset.count())
+        Long totalCount = queryFactory.select(asset.id.countDistinct())
                 .from(asset)
                 .innerJoin(assetTag).on(asset.eq(assetTag.asset))
                 .innerJoin(category).on(category.id.eq(assetTag.category.id).and(category.categoryName.eq(categoryName)))

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
@@ -36,6 +36,7 @@ public class AssetQueryRepository {
                         asset.discount,
                         asset.discountPrice,
                         asset.releaseDate,
+                        asset.thumbnailUrl,
                         asset.rating,
                         asset.reviewCount,
                         asset.wishCount,
@@ -66,6 +67,7 @@ public class AssetQueryRepository {
                         asset.discount,
                         asset.discountPrice,
                         asset.releaseDate,
+                        asset.thumbnailUrl,
                         asset.rating,
                         asset.reviewCount,
                         asset.wishCount)
@@ -93,6 +95,7 @@ public class AssetQueryRepository {
                         asset.discount,
                         asset.discountPrice,
                         asset.releaseDate,
+                        asset.thumbnailUrl,
                         asset.rating,
                         asset.reviewCount,
                         asset.wishCount,
@@ -131,6 +134,7 @@ public class AssetQueryRepository {
                         asset.discount,
                         asset.discountPrice,
                         asset.releaseDate,
+                        asset.thumbnailUrl,
                         asset.rating,
                         asset.reviewCount,
                         asset.wishCount)
@@ -165,6 +169,7 @@ public class AssetQueryRepository {
                         asset.discount,
                         asset.discountPrice,
                         asset.releaseDate,
+                        asset.thumbnailUrl,
                         asset.rating,
                         asset.reviewCount,
                         asset.wishCount,
@@ -203,6 +208,7 @@ public class AssetQueryRepository {
                         asset.discount,
                         asset.discountPrice,
                         asset.releaseDate,
+                        asset.thumbnailUrl,
                         asset.rating,
                         asset.reviewCount,
                         asset.wishCount)

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
@@ -1,6 +1,7 @@
 package com.phoenix.assetbe.model.asset;
 
 import com.phoenix.assetbe.dto.asset.AssetResponse;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -250,8 +251,15 @@ public class AssetQueryRepository {
     }
 
     public List<Asset> findAllById(List<Long> userIds) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(asset.status.eq(true));
+        for(Long userId : userIds) {
+            builder.or(asset.id.eq(userId));
+        }
+
         return queryFactory.selectFrom(asset)
-                .where(asset.status.eq(true).and(asset.id.eq(userIds)))
+                .where(builder)
                 .fetch();
     }
 

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetTagQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetTagQueryRepository.java
@@ -16,6 +16,7 @@ import static com.phoenix.assetbe.model.asset.QTag.tag;
 @RequiredArgsConstructor
 @Repository
 public class AssetTagQueryRepository {
+
     private final JPAQueryFactory queryFactory;
 
     public List<String> findTagNameListByAssetId(Long assetId) {

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetTagQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetTagQueryRepository.java
@@ -1,5 +1,7 @@
 package com.phoenix.assetbe.model.asset;
 
+import com.phoenix.assetbe.dto.asset.CategoryResponse;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -7,6 +9,8 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 import static com.phoenix.assetbe.model.asset.QAssetTag.assetTag;
+import static com.phoenix.assetbe.model.asset.QCategory.category;
+import static com.phoenix.assetbe.model.asset.QSubCategory.subCategory;
 import static com.phoenix.assetbe.model.asset.QTag.tag;
 
 @RequiredArgsConstructor
@@ -20,6 +24,45 @@ public class AssetTagQueryRepository {
                 .join(assetTag.tag, tag)
                 .where(assetTag.asset.id.eq(assetId))
                 .orderBy(tag.tagName.asc())
+                .fetch();
+    }
+
+    public List<CategoryResponse.CategoryOutDTO.CountByCategory> findAssetCountByCategory() {
+        return queryFactory
+                .select(Projections.constructor(CategoryResponse.CategoryOutDTO.CountByCategory.class,
+                        assetTag.category.categoryName,
+                        assetTag.asset.id.countDistinct()))
+                .from(assetTag)
+                .leftJoin(category).on(category.id.eq(assetTag.category.id))
+                .groupBy(category.categoryName)
+                .fetch();
+    }
+
+    public List<CategoryResponse.CategoryOutDTO.CountBySubCategory> findAssetCountBySubCategory() {
+        return queryFactory
+                .select(Projections.constructor(CategoryResponse.CategoryOutDTO.CountBySubCategory.class,
+                                assetTag.category.categoryName,
+                                assetTag.subCategory.subCategoryName,
+                                assetTag.asset.id.countDistinct()))
+                .from(assetTag)
+                .leftJoin(category).on(category.id.eq(assetTag.category.id))
+                .leftJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
+                .groupBy(category.categoryName, subCategory.subCategoryName)
+                .fetch();
+    }
+
+    public List<CategoryResponse.CategoryOutDTO.CountByTag> findAssetCountByTag() {
+        return queryFactory
+                .select(Projections.constructor(CategoryResponse.CategoryOutDTO.CountByTag.class,
+                        assetTag.category.categoryName,
+                        assetTag.subCategory.subCategoryName,
+                        assetTag.tag.tagName,
+                        assetTag.asset.countDistinct()))
+                .from(assetTag)
+                .leftJoin(category).on(category.id.eq(assetTag.category.id))
+                .leftJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
+                .leftJoin(tag).on(tag.id.eq(assetTag.tag.id))
+                .groupBy(category.categoryName, subCategory.subCategoryName, tag.tagName)
                 .fetch();
     }
 }

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetTagQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetTagQueryRepository.java
@@ -8,10 +8,8 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-import static com.phoenix.assetbe.model.asset.QAsset.asset;
 import static com.phoenix.assetbe.model.asset.QAssetTag.assetTag;
 import static com.phoenix.assetbe.model.asset.QCategory.category;
-import static com.phoenix.assetbe.model.asset.QPreview.preview;
 import static com.phoenix.assetbe.model.asset.QSubCategory.subCategory;
 import static com.phoenix.assetbe.model.asset.QTag.tag;
 

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetTagQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetTagQueryRepository.java
@@ -8,8 +8,10 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static com.phoenix.assetbe.model.asset.QAsset.asset;
 import static com.phoenix.assetbe.model.asset.QAssetTag.assetTag;
 import static com.phoenix.assetbe.model.asset.QCategory.category;
+import static com.phoenix.assetbe.model.asset.QPreview.preview;
 import static com.phoenix.assetbe.model.asset.QSubCategory.subCategory;
 import static com.phoenix.assetbe.model.asset.QTag.tag;
 

--- a/src/main/java/com/phoenix/assetbe/model/asset/MyAssetQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/MyAssetQueryRepository.java
@@ -27,7 +27,6 @@ import static com.phoenix.assetbe.model.asset.QMyAsset.myAsset;
 public class MyAssetQueryRepository {
 
     private final JPAQueryFactory queryFactory;
-    private final AssetQueryRepository assetQueryRepository;
 
     public boolean existsAssetIdAndUserId(Long assetId, Long userId) {
         Integer fetchOne = queryFactory

--- a/src/main/java/com/phoenix/assetbe/model/asset/PreviewQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/PreviewQueryRepository.java
@@ -1,0 +1,25 @@
+package com.phoenix.assetbe.model.asset;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.phoenix.assetbe.model.asset.QAsset.asset;
+import static com.phoenix.assetbe.model.asset.QPreview.preview;
+
+@RequiredArgsConstructor
+@Repository
+public class PreviewQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<String> findPreviewListByAssetId(Long assetId) {
+        return queryFactory.select(preview.previewUrl)
+                .from(preview)
+                .where(asset.id.eq(assetId))
+                .orderBy(preview.id.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/phoenix/assetbe/model/asset/ReviewQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/ReviewQueryRepository.java
@@ -16,9 +16,15 @@ import static com.phoenix.assetbe.model.user.QUser.user;
 public class ReviewQueryRepository {
     private final JPAQueryFactory queryFactory;
 
-    public List<ReviewResponse.ReviewsOutDTO.Reviews> findReviewsByAssetId(Long assetId) {
-        return queryFactory.select(Projections.constructor(ReviewResponse.ReviewsOutDTO.Reviews.class,
-                review.id, review.rating, review.content, review.user.id, review.user.firstName, review.user.lastName))
+    public List<ReviewResponse.ReviewListOutDTO.ReviewOutDTO> findReviewListByAssetId(Long assetId) {
+        return queryFactory.select(Projections.constructor(ReviewResponse.ReviewListOutDTO.ReviewOutDTO.class,
+                        review.id,
+                        review.rating,
+                        review.content,
+                        review.user.id,
+                        review.user.firstName,
+                        review.user.lastName)
+                )
                 .from(review)
                 .innerJoin(review.user, user)
                 .where(review.asset.id.eq(assetId))
@@ -28,7 +34,13 @@ public class ReviewQueryRepository {
 
     public ReviewResponse.ReviewOutDTO findReviewByUserIdAndAssetId(Long userId, Long assetId) {
         return queryFactory.select(Projections.constructor(ReviewResponse.ReviewOutDTO.class,
-                review.user.id, review.asset.id, review.id, review.content, review.rating, review.asset.rating))
+                        review.user.id,
+                        review.asset.id,
+                        review.id,
+                        review.content,
+                        review.rating,
+                        review.asset.rating)
+                )
                 .from(review)
                 .innerJoin(review.asset)
                 .where(review.user.id.eq(userId).and(review.asset.id.eq(assetId)))
@@ -37,6 +49,13 @@ public class ReviewQueryRepository {
 
     public Review findReviewByUserIdAndAssetIdWithoutDTO(Long userId, Long assetId) {
         return queryFactory.selectFrom(review)
+                .where(review.user.id.eq(userId).and(review.asset.id.eq(assetId)))
+                .fetchOne();
+    }
+
+    public Long findReviewIdByUserIdAndAssetId(Long userId, Long assetId) {
+        return queryFactory.select(review.id)
+                .from(review)
                 .where(review.user.id.eq(userId).and(review.asset.id.eq(assetId)))
                 .fetchOne();
     }

--- a/src/main/java/com/phoenix/assetbe/model/asset/ReviewRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/ReviewRepository.java
@@ -1,13 +1,6 @@
 package com.phoenix.assetbe.model.asset;
 
-import com.phoenix.assetbe.dto.asset.ReviewResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    @Query("SELECT r.id, r.rating, r.content, r.user.id, r.user.firstName, r.user.lastName FROM Review r WHERE r.asset.id = :assetId ORDER BY r.createdAt, r.updatedAt DESC")
-    List<ReviewResponse.ReviewsOutDTO.Reviews> findByAssetId(@Param("assetId") Long assetId);
 }

--- a/src/main/java/com/phoenix/assetbe/model/wish/WishListQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/wish/WishListQueryRepository.java
@@ -4,19 +4,30 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 import static com.phoenix.assetbe.model.wish.QWishList.wishList;
 
 @RequiredArgsConstructor
 @Repository
 public class WishListQueryRepository {
-    private final JPAQueryFactory jpaQueryFactory;
+
+    private final JPAQueryFactory queryFactory;
 
     public boolean existsAssetIdAndUserId(Long assetId, Long userId) {
-        Integer fetchOne = jpaQueryFactory
+        Integer fetchOne = queryFactory
                 .selectOne()
                 .from(wishList)
                 .where(wishList.asset.id.eq(assetId).and(wishList.user.id.eq(userId)))
                 .fetchFirst(); // limit 1
         return fetchOne != null; // 1개가 있는지 없는지 판단 (없으면 null 이므로 null 체크)
+    }
+
+    public Long findIdByAssetIdAndUserId(Long assetId, Long userId) {
+        return queryFactory
+                .select(wishList.id)
+                .from(wishList)
+                .where(wishList.asset.id.eq(assetId).and(wishList.user.id.eq(userId)))
+                .fetchOne();
     }
 }

--- a/src/main/java/com/phoenix/assetbe/model/wish/WishListRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/wish/WishListRepository.java
@@ -1,10 +1,6 @@
 package com.phoenix.assetbe.model.wish;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface WishListRepository extends JpaRepository<WishList, Long> {
-    @Query("SELECT w.id FROM WishList w WHERE w.asset.id = :assetId AND w.user.id = :userId")
-    Long findIdByAssetIdAndUserId(@Param("assetId") Long assetId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/phoenix/assetbe/service/AssetService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AssetService.java
@@ -7,7 +7,6 @@ import com.phoenix.assetbe.model.asset.*;
 import com.phoenix.assetbe.dto.asset.AssetResponse;
 import com.phoenix.assetbe.core.exception.Exception500;
 import com.phoenix.assetbe.model.wish.WishListQueryRepository;
-import com.phoenix.assetbe.model.wish.WishListRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -89,13 +88,13 @@ public class AssetService {
     }
 
     public Asset findAssetById(Long assetId){
-        Asset assetPS = assetQueryRepository.findById(assetId).orElseThrow(
+        Asset assetPS = assetRepository.findById(assetId).orElseThrow(
                 () -> new Exception400("id", "존재하지 않는 에셋입니다. "));
         return assetPS;
     }
 
     public List<Asset> findAllAssetById(List<Long> assetIds){
-        List<Asset> assetList = assetQueryRepository.findAllById(assetIds);
+        List<Asset> assetList = assetRepository.findAllById(assetIds);
         return assetList;
     }
 }

--- a/src/main/java/com/phoenix/assetbe/service/AssetService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AssetService.java
@@ -2,6 +2,7 @@ package com.phoenix.assetbe.service;
 
 import com.phoenix.assetbe.core.auth.session.MyUserDetails;
 import com.phoenix.assetbe.core.exception.Exception400;
+import com.phoenix.assetbe.core.exception.Exception404;
 import com.phoenix.assetbe.model.asset.Asset;
 import com.phoenix.assetbe.model.asset.AssetQueryRepository;
 import com.phoenix.assetbe.model.asset.AssetRepository;
@@ -37,6 +38,9 @@ public class AssetService {
             assetList = assetQueryRepository.findAssetListWithUserIdAndPaging(userId, pageable);
         }else {
             assetList = assetQueryRepository.findAssetListWithPaging(pageable);
+        }
+        if (assetList.getContent().isEmpty()) {
+            throw new Exception404("에셋이 존재하지 않습니다. ");
         }
         return new AssetResponse.AssetListOutDTO(assetList);
     }

--- a/src/main/java/com/phoenix/assetbe/service/AssetService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AssetService.java
@@ -30,15 +30,15 @@ public class AssetService {
     private final WishListRepository wishListRepository;
     private final AssetTagQueryRepository assetTagQueryRepository;
 
-    public AssetResponse.AssetsOutDTO getAssetsService(Pageable pageable, MyUserDetails myUserDetails) {
-        Page<AssetResponse.AssetsOutDTO.AssetDetail> assetDetails;
+    public AssetResponse.AssetListOutDTO getAssetListService(Pageable pageable, MyUserDetails myUserDetails) {
+        Page<AssetResponse.AssetListOutDTO.AssetDetail> assetDetailList;
         if(myUserDetails != null) {
             Long userId = myUserDetails.getUser().getId();
-            assetDetails = assetQueryRepository.findAssetsWithUserIdAndPaging(userId, pageable);
+            assetDetailList = assetQueryRepository.findAssetListWithUserIdAndPaging(userId, pageable);
         }else {
-            assetDetails = assetQueryRepository.findAssetsWithPaging(pageable);
+            assetDetailList = assetQueryRepository.findAssetListWithPaging(pageable);
         }
-        return new AssetResponse.AssetsOutDTO(assetDetails);
+        return new AssetResponse.AssetListOutDTO(assetDetailList);
     }
 
     @Transactional
@@ -59,20 +59,20 @@ public class AssetService {
         return new AssetResponse.AssetDetailsOutDTO(assetPS, wishListId, tagNameList);
     }
 
-    public AssetResponse.AssetsOutDTO getAssetListByCategoryService(String categoryName, Pageable pageable, MyUserDetails myUserDetails) {
-        Page<AssetResponse.AssetsOutDTO.AssetDetail> assetDetailList;
+    public AssetResponse.AssetListOutDTO getAssetListByCategoryService(String categoryName, Pageable pageable, MyUserDetails myUserDetails) {
+        Page<AssetResponse.AssetListOutDTO.AssetDetail> assetDetailList;
         if(myUserDetails != null) {
             Long userId = myUserDetails.getUser().getId();
             assetDetailList = assetQueryRepository.findAssetListWithUserIdAndPaginationByCategory(userId, categoryName, pageable);
         }else {
             assetDetailList = assetQueryRepository.findAssetListWithPaginationByCategory(categoryName, pageable);
         }
-        return new AssetResponse.AssetsOutDTO(assetDetailList);
+        return new AssetResponse.AssetListOutDTO(assetDetailList);
     }
 
-    public AssetResponse.AssetsOutDTO getAssetListBySubCategoryService(String categoryName, String subCategoryName,
+    public AssetResponse.AssetListOutDTO getAssetListBySubCategoryService(String categoryName, String subCategoryName,
                                                                        Pageable pageable, MyUserDetails myUserDetails) {
-        Page<AssetResponse.AssetsOutDTO.AssetDetail> assetDetailList;
+        Page<AssetResponse.AssetListOutDTO.AssetDetail> assetDetailList;
         if(myUserDetails != null) {
             Long userId = myUserDetails.getUser().getId();
             assetDetailList = assetQueryRepository
@@ -81,7 +81,7 @@ public class AssetService {
             assetDetailList = assetQueryRepository
                     .findAssetListWithPaginationBySubCategory(categoryName, subCategoryName, pageable);
         }
-        return new AssetResponse.AssetsOutDTO(assetDetailList);
+        return new AssetResponse.AssetListOutDTO(assetDetailList);
     }
 
     public Asset findAssetById(Long assetId){

--- a/src/main/java/com/phoenix/assetbe/service/AssetService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AssetService.java
@@ -3,12 +3,10 @@ package com.phoenix.assetbe.service;
 import com.phoenix.assetbe.core.auth.session.MyUserDetails;
 import com.phoenix.assetbe.core.exception.Exception400;
 import com.phoenix.assetbe.core.exception.Exception404;
-import com.phoenix.assetbe.model.asset.Asset;
-import com.phoenix.assetbe.model.asset.AssetQueryRepository;
-import com.phoenix.assetbe.model.asset.AssetRepository;
+import com.phoenix.assetbe.model.asset.*;
 import com.phoenix.assetbe.dto.asset.AssetResponse;
 import com.phoenix.assetbe.core.exception.Exception500;
-import com.phoenix.assetbe.model.asset.AssetTagQueryRepository;
+import com.phoenix.assetbe.model.wish.WishListQueryRepository;
 import com.phoenix.assetbe.model.wish.WishListRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -28,8 +26,9 @@ public class AssetService {
 
     private final AssetRepository assetRepository;
     private final AssetQueryRepository assetQueryRepository;
-    private final WishListRepository wishListRepository;
+    private final WishListQueryRepository wishListQueryRepository;
     private final AssetTagQueryRepository assetTagQueryRepository;
+    private final PreviewQueryRepository previewQueryRepository;
 
     public AssetResponse.AssetListOutDTO getAssetListService(Pageable pageable, MyUserDetails myUserDetails) {
         Page<AssetResponse.AssetListOutDTO.AssetOutDTO> assetList;
@@ -50,17 +49,18 @@ public class AssetService {
         Long wishListId = null;
         if (myUserDetails != null) {
             Long userId = myUserDetails.getUser().getId();
-            wishListId = wishListRepository.findIdByAssetIdAndUserId(assetId, userId);
+            wishListId = wishListQueryRepository.findIdByAssetIdAndUserId(assetId, userId);
         }
         Asset assetPS = findAssetById(assetId);
         List<String> tagNameList = assetTagQueryRepository.findTagNameListByAssetId(assetId);
+        List<String> previewList = previewQueryRepository.findPreviewListByAssetId(assetId);
         assetPS.increaseVisitCount();
         try {
             assetRepository.save(assetPS);
         }catch (Exception e){
             throw new Exception500("view 증가 실패");
         }
-        return new AssetResponse.AssetDetailsOutDTO(assetPS, wishListId, null, tagNameList);
+        return new AssetResponse.AssetDetailsOutDTO(assetPS, wishListId, previewList, tagNameList);
     }
 
     public AssetResponse.AssetListOutDTO getAssetListByCategoryService(String categoryName, Pageable pageable, MyUserDetails myUserDetails) {

--- a/src/main/java/com/phoenix/assetbe/service/AssetService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AssetService.java
@@ -31,14 +31,14 @@ public class AssetService {
     private final AssetTagQueryRepository assetTagQueryRepository;
 
     public AssetResponse.AssetListOutDTO getAssetListService(Pageable pageable, MyUserDetails myUserDetails) {
-        Page<AssetResponse.AssetListOutDTO.AssetDetail> assetDetailList;
+        Page<AssetResponse.AssetListOutDTO.AssetOutDTO> assetList;
         if(myUserDetails != null) {
             Long userId = myUserDetails.getUser().getId();
-            assetDetailList = assetQueryRepository.findAssetListWithUserIdAndPaging(userId, pageable);
+            assetList = assetQueryRepository.findAssetListWithUserIdAndPaging(userId, pageable);
         }else {
-            assetDetailList = assetQueryRepository.findAssetListWithPaging(pageable);
+            assetList = assetQueryRepository.findAssetListWithPaging(pageable);
         }
-        return new AssetResponse.AssetListOutDTO(assetDetailList);
+        return new AssetResponse.AssetListOutDTO(assetList);
     }
 
     @Transactional
@@ -56,42 +56,42 @@ public class AssetService {
         }catch (Exception e){
             throw new Exception500("view 증가 실패");
         }
-        return new AssetResponse.AssetDetailsOutDTO(assetPS, wishListId, tagNameList);
+        return new AssetResponse.AssetDetailsOutDTO(assetPS, wishListId, null, tagNameList);
     }
 
     public AssetResponse.AssetListOutDTO getAssetListByCategoryService(String categoryName, Pageable pageable, MyUserDetails myUserDetails) {
-        Page<AssetResponse.AssetListOutDTO.AssetDetail> assetDetailList;
+        Page<AssetResponse.AssetListOutDTO.AssetOutDTO> assetList;
         if(myUserDetails != null) {
             Long userId = myUserDetails.getUser().getId();
-            assetDetailList = assetQueryRepository.findAssetListWithUserIdAndPaginationByCategory(userId, categoryName, pageable);
+            assetList = assetQueryRepository.findAssetListWithUserIdAndPaginationByCategory(userId, categoryName, pageable);
         }else {
-            assetDetailList = assetQueryRepository.findAssetListWithPaginationByCategory(categoryName, pageable);
+            assetList = assetQueryRepository.findAssetListWithPaginationByCategory(categoryName, pageable);
         }
-        return new AssetResponse.AssetListOutDTO(assetDetailList);
+        return new AssetResponse.AssetListOutDTO(assetList);
     }
 
     public AssetResponse.AssetListOutDTO getAssetListBySubCategoryService(String categoryName, String subCategoryName,
                                                                        Pageable pageable, MyUserDetails myUserDetails) {
-        Page<AssetResponse.AssetListOutDTO.AssetDetail> assetDetailList;
+        Page<AssetResponse.AssetListOutDTO.AssetOutDTO> assetList;
         if(myUserDetails != null) {
             Long userId = myUserDetails.getUser().getId();
-            assetDetailList = assetQueryRepository
+            assetList = assetQueryRepository
                     .findAssetListWithUserIdAndPaginationBySubCategory(userId, categoryName, subCategoryName, pageable);
         }else {
-            assetDetailList = assetQueryRepository
+            assetList = assetQueryRepository
                     .findAssetListWithPaginationBySubCategory(categoryName, subCategoryName, pageable);
         }
-        return new AssetResponse.AssetListOutDTO(assetDetailList);
+        return new AssetResponse.AssetListOutDTO(assetList);
     }
 
     public Asset findAssetById(Long assetId){
-        Asset assetPS = assetRepository.findById(assetId).orElseThrow(
+        Asset assetPS = assetQueryRepository.findById(assetId).orElseThrow(
                 () -> new Exception400("id", "존재하지 않는 에셋입니다. "));
         return assetPS;
     }
 
     public List<Asset> findAllAssetById(List<Long> assetIds){
-        List<Asset> assetList = assetRepository.findAllById(assetIds);
+        List<Asset> assetList = assetQueryRepository.findAllById(assetIds);
         return assetList;
     }
 }

--- a/src/main/java/com/phoenix/assetbe/service/CategoryService.java
+++ b/src/main/java/com/phoenix/assetbe/service/CategoryService.java
@@ -1,6 +1,6 @@
 package com.phoenix.assetbe.service;
 
-import com.phoenix.assetbe.dto.asset.AssetResponse;
+import com.phoenix.assetbe.dto.asset.CategoryResponse;
 import com.phoenix.assetbe.model.asset.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,65 +19,96 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class CategoryService {
 
-    private final AssetTagRepository assetTagRepository;
+    private final AssetTagQueryRepository assetTagQueryRepository;
 
-    public AssetResponse.CategoryOutDTO getCategoryListService() {
-        List<AssetTag> assetTags = assetTagRepository.findAll(); // 모든 AssetTag 레코드를 가져옴
+    public CategoryResponse.CategoryOutDTO getCategoryListService() {
 
-        Map<Category, List<AssetTag>> categoryMap = assetTags.stream()
-                .collect(Collectors.groupingBy(AssetTag::getCategory)); // 카테고리별로 AssetTag를 그룹화
+        List<CategoryResponse.CategoryOutDTO.CountByCategory> countByCategoryList
+                = assetTagQueryRepository.findAssetCountByCategory();
 
-        List<AssetResponse.CategoryOutDTO.CategoryDTO> categoryDTOList = new ArrayList<>();
+        List<CategoryResponse.CategoryOutDTO.CountBySubCategory> countBySubCategoryList
+                = assetTagQueryRepository.findAssetCountBySubCategory();
 
-        for (Map.Entry<Category, List<AssetTag>> entry : categoryMap.entrySet()) {
-            Category category = entry.getKey();
-            List<AssetTag> categoryAssetTags = entry.getValue();
+        List<CategoryResponse.CategoryOutDTO.CountByTag> countByTagList
+                = assetTagQueryRepository.findAssetCountByTag();
 
-            List<String> tagList = categoryAssetTags.stream()
-                    .map(assetTag -> assetTag.getTag().getTagName())
+        // Category 별로 그룹화된 Map을 생성한다.
+        Map<String, List<CategoryResponse.CategoryOutDTO.CountByTag>> categoryMap
+                = countByTagList.stream()
+                .collect(Collectors.groupingBy(CategoryResponse.CategoryOutDTO.CountByTag::getCategoryName));
+
+        // 결과를 담을 리스트를 생성한다.
+        List<CategoryResponse.CategoryOutDTO.CategoryDTO> categoryDTOList = new ArrayList<>();
+
+        // Category 별로 처리한다.
+        for (Map.Entry<String, List<CategoryResponse.CategoryOutDTO.CountByTag>> entry : categoryMap.entrySet()) {
+            String categoryName = entry.getKey();
+            List<CategoryResponse.CategoryOutDTO.CountByTag> categoryDataList = entry.getValue();
+
+            // Tag 리스트를 생성한다.
+            List<String> categoryTagList = categoryDataList.stream()
+                    .map(CategoryResponse.CategoryOutDTO.CountByTag::getTagName)
                     .distinct()
                     .sorted()
                     .collect(Collectors.toList());
 
-            Map<SubCategory, List<AssetTag>> subCategoryMap = categoryAssetTags.stream()
-                    .collect(Collectors.groupingBy(AssetTag::getSubCategory)); // 서브카테고리별로 AssetTag를 그룹화
+            // SubCategory 별로 그룹화된 Map을 생성한다.
+            Map<String, List<CategoryResponse.CategoryOutDTO.CountByTag>> subCategoryMap = categoryDataList.stream()
+                    .collect(Collectors.groupingBy(CategoryResponse.CategoryOutDTO.CountByTag::getSubCategoryName));
 
-            List<AssetResponse.CategoryOutDTO.SubCategoryDTO> subCategoryDTOList = new ArrayList<>();
+            // SubCategory 리스트를 생성한다.
+            List<CategoryResponse.CategoryOutDTO.SubCategoryDTO> subCategoryDTOList = new ArrayList<>();
 
-            for (Map.Entry<SubCategory, List<AssetTag>> subCategoryEntry : subCategoryMap.entrySet()) {
-                SubCategory subCategory = subCategoryEntry.getKey();
-                List<AssetTag> subCategoryAssetTags = subCategoryEntry.getValue();
+            // SubCategory 별로 처리한다.
+            for (Map.Entry<String, List<CategoryResponse.CategoryOutDTO.CountByTag>> subCategoryEntry : subCategoryMap.entrySet()) {
+                String subCategoryName = subCategoryEntry.getKey();
+                List<CategoryResponse.CategoryOutDTO.CountByTag> subCategoryDataList = subCategoryEntry.getValue();
 
-                List<String> subCategoryTagList = subCategoryAssetTags.stream()
-                        .map(assetTag -> assetTag.getTag().getTagName())
+                // SubCategory 별로 Student 리스트를 생성한다.
+                List<String> subCategoryTagList = subCategoryDataList.stream()
+                        .map(CategoryResponse.CategoryOutDTO.CountByTag::getTagName)
                         .distinct()
                         .sorted()
                         .collect(Collectors.toList());
 
-                AssetResponse.CategoryOutDTO.SubCategoryDTO subCategoryDTO = new AssetResponse.CategoryOutDTO.SubCategoryDTO(
-                        subCategory.getSubCategoryName(), null, subCategoryTagList
-                );
+                Long count = null;
+                for(CategoryResponse.CategoryOutDTO.CountBySubCategory countBySubCategory : countBySubCategoryList){
+                    if( countBySubCategory.getCategoryName().equals(categoryName)
+                            && countBySubCategory.getSubCategoryName().equals(subCategoryName)) {
+                        count = countBySubCategory.getSubCategoryCount();
+                        break;
+                    }
+                }
 
+                // subCategoryDTO 객체를 생성하여 subCategoryList에 추가한다.
+                CategoryResponse.CategoryOutDTO.SubCategoryDTO subCategoryDTO
+                        = new CategoryResponse.CategoryOutDTO.SubCategoryDTO(subCategoryName, count, subCategoryTagList);
                 subCategoryDTOList.add(subCategoryDTO);
             }
 
-            AssetResponse.CategoryOutDTO.CategoryDTO categoryDTO = new AssetResponse.CategoryOutDTO.CategoryDTO(
-                    category.getCategoryName(), null, tagList, subCategoryDTOList
+            Long count = null;
+            for(CategoryResponse.CategoryOutDTO.CountByCategory countByCategory : countByCategoryList){
+                if( countByCategory.getCategoryName().equals(categoryName)) {
+                    count = countByCategory.getCategoryCount();
+                    break;
+                }
+            }
 
-            );
-
-            categoryDTOList.add(categoryDTO);
+            // ResultDTO 객체를 생성하여 결과 리스트에 추가한다.
+            CategoryResponse.CategoryOutDTO.CategoryDTO resultDTO
+                    = new CategoryResponse.CategoryOutDTO.CategoryDTO(categoryName, count, categoryTagList, subCategoryDTOList);
+            categoryDTOList.add(resultDTO);
         }
 
         // categoryName을 기준으로 카테고리 정렬
-        categoryDTOList.sort(Comparator.comparing(AssetResponse.CategoryOutDTO.CategoryDTO::getCategoryName));
+        categoryDTOList.sort(Comparator.comparing(CategoryResponse.CategoryOutDTO.CategoryDTO::getCategoryName));
 
         // subCategoryName을 기준으로 서브카테고리 정렬
-        for (AssetResponse.CategoryOutDTO.CategoryDTO categoryDTO : categoryDTOList) {
-            categoryDTO.getSubCategoryList().sort(Comparator.comparing(AssetResponse.CategoryOutDTO.SubCategoryDTO::getSubCategoryName));
+        for (CategoryResponse.CategoryOutDTO.CategoryDTO categoryDTO : categoryDTOList) {
+            categoryDTO.getSubCategoryList().sort(Comparator.comparing(CategoryResponse.CategoryOutDTO.SubCategoryDTO::getSubCategoryName));
         }
 
-        return new AssetResponse.CategoryOutDTO(categoryDTOList);
+        return new CategoryResponse.CategoryOutDTO(categoryDTOList);
     }
 }
 

--- a/src/main/java/com/phoenix/assetbe/service/ReviewService.java
+++ b/src/main/java/com/phoenix/assetbe/service/ReviewService.java
@@ -148,9 +148,12 @@ public class ReviewService {
 
             Asset assetPS = assetService.findAssetById(assetId);
 
-            Double reviewRatingSum = reviewQueryRepository.findSumRatingByAssetId(assetId);
-            assetPS.calculateRatingOnDeleteReview(assetPS, reviewRatingSum);
-
+            Optional<Double> reviewRatingSum = Optional.ofNullable(reviewQueryRepository.findSumRatingByAssetId(assetId));
+            if(reviewRatingSum.isPresent()) {
+                assetPS.calculateRatingOnDeleteReview(assetPS, reviewRatingSum.get());
+            }else{
+                assetPS.calculateRatingOnDeleteReview(assetPS);
+            }
             try {
                 assetRepository.save(assetPS);
             } catch (Exception e) {

--- a/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
@@ -4,6 +4,7 @@ import com.phoenix.assetbe.core.config.MyTestSetUp;
 import com.phoenix.assetbe.core.dummy.DummyEntity;
 import com.phoenix.assetbe.model.asset.*;
 import com.phoenix.assetbe.model.user.*;
+import com.phoenix.assetbe.service.AssetService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -43,6 +44,12 @@ public class AssetControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private AssetService assetService;
+
+    @Autowired
+    private PreviewRepository previewRepository;
+
     @BeforeEach
     public void setUp() throws Exception {
         List<User> userList = myTestSetUp.saveUser();
@@ -56,6 +63,11 @@ public class AssetControllerTest {
     @Test
     public void get_asset_details_test() throws Exception {
         // Given
+        Asset asset = assetService.findAssetById(3L);
+        Preview preview1 = Preview.builder().asset(asset).previewUrl("asset3_1_previewUrl").build();
+        Preview preview2 = Preview.builder().asset(asset).previewUrl("asset3_2_previewUrl").build();
+        Preview preview3 = Preview.builder().asset(asset).previewUrl("asset3_3_previewUrl").build();
+        previewRepository.saveAll(Arrays.asList(preview1, preview2, preview3));
         Long id = 3L;
 
         // When
@@ -76,6 +88,11 @@ public class AssetControllerTest {
     @Test
     public void get_asset_details_with_user_test() throws Exception {
         // Given
+        Asset asset = assetService.findAssetById(10L);
+        Preview preview1 = Preview.builder().asset(asset).previewUrl("asset10_1_previewUrl").build();
+        Preview preview2 = Preview.builder().asset(asset).previewUrl("asset10_2_previewUrl").build();
+        Preview preview3 = Preview.builder().asset(asset).previewUrl("asset10_3_previewUrl").build();
+        previewRepository.saveAll(Arrays.asList(preview1, preview2, preview3));
         Long id = 10L;
 
         // When

--- a/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
@@ -23,8 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("에셋 컨트롤러 TEST")
 @ActiveProfiles("test")
@@ -52,174 +52,191 @@ public class AssetControllerTest {
         myTestSetUp.saveCategoryAndSubCategoryAndTag(assetList);
     }
 
-    @DisplayName("에셋 상세정보 비로그인 성공")
+    @DisplayName("에셋 상세정보 비로그인유저 성공")
     @Test
     public void get_asset_details_test() throws Exception {
-        // given
+        // Given
         Long id = 3L;
 
-        // when
-        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets/{id}/details",id));
-        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-        System.out.println("테스트 : " + responseBody);
+        // When
+        ResultActions resultActions = mockMvc.perform(get("/assets/{id}/details", id));
 
         // Then
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 response : " + responseBody);
+
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("성공"))
-                .andExpect(jsonPath("$.status").value(200));
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetId").value(3L));
     }
 
-    @DisplayName("에셋 상세정보 로그인 성공")
-    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("에셋 상세정보 로그인유저 성공")
+    @WithUserDetails(value = "유현주@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
     public void get_asset_details_with_user_test() throws Exception {
-        // given
-        Long id = 1L;
+        // Given
+        Long id = 10L;
 
-        // when
-        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets/{id}/details",id));
-        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-        System.out.println("테스트 : " + responseBody);
+        // When
+        ResultActions resultActions = mockMvc.perform(get("/assets/{id}/details", id));
 
         // Then
-        resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.msg").value("성공"))
-                .andExpect(jsonPath("$.status").value(200));
-    }
-
-    @DisplayName("개별에셋 로그인 성공")
-    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-    @Test
-    public void get_assets_with_user_test() throws Exception {
-        // given
-        String page = "8";
-        String size = "3";
-        // when
-        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets")
-                .param("page", page)
-                .param("size", size));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-        System.out.println("테스트 : " + responseBody);
+        System.out.println("테스트 response : " + responseBody);
 
-        // Then
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("성공"))
-                .andExpect(jsonPath("$.status").value(200));
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetId").value(10L))
+                .andExpect(jsonPath("$.data.wishlistId").value(1L));
     }
 
-    @DisplayName("개별에셋 비로그인 성공")
+    @DisplayName("개별에셋 비로그인유저 성공")
     @Test
-    public void get_assets_test() throws Exception {
-        // given
+    public void get_asset_list_test() throws Exception {
+        // Given
         String page = "0";
         String size = "3";
 
-        // when
-        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets")
-                .param("page", page)
-                .param("size", size));
-        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-        System.out.println("테스트 : " + responseBody);
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets").param("page", page).param("size", size));
 
         // Then
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 response : " + responseBody);
+
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("성공"))
-                .andExpect(jsonPath("$.status").value(200));
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetList[0].assetId").value(30L))
+                .andExpect(jsonPath("$.data.assetList[0].wishlistId").doesNotExist())
+                .andExpect(jsonPath("$.data.assetList[0].cartId").doesNotExist());
     }
 
-    @DisplayName("카테고리별 에셋 조회 로그인 성공")
+    @DisplayName("개별에셋 로그인유저 성공")
+    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void get_asset_list_with_user_test() throws Exception {
+        // Given
+        String page = "8";
+        String size = "3";
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets").param("page", page).param("size", size));
+
+        // Then
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 response : " + responseBody);
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetList[0].assetId").value(6L))
+                .andExpect(jsonPath("$.data.assetList[0].wishlistId").doesNotExist())
+                .andExpect(jsonPath("$.data.assetList[0].cartId").value(18L));
+    }
+
+    @DisplayName("카테고리별 에셋 조회 비로그인유저 성공")
+    @Test
+    public void get_asset_list_with_pagination_by_category_test() throws Exception {
+        // Given
+        String categoryName = "luxury";
+        String page = "0";
+        String size = "4";
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets/{categoryName}", categoryName).param("page", page).param("size", size));
+
+        // Then
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 response : " + responseBody);
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetList[0].assetId").value(24L))
+                .andExpect(jsonPath("$.data.assetList[0].assetName").value("luxury dancer"))
+                .andExpect(jsonPath("$.data.assetList[0].wishlistId").doesNotExist())
+                .andExpect(jsonPath("$.data.assetList[0].cartId").doesNotExist());
+    }
+
+    @DisplayName("카테고리별 에셋 조회 로그인유저 성공")
     @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
     public void get_asset_list_with_user_id_and_pagination_by_category_test() throws Exception {
-        // given
+        // Given
         String categoryName = "luxury";
-        String page = "0";
+        String page = "1";
         String size = "4";
 
-        // when
-        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets/{categoryName}",categoryName)
-                .param("page", page)
-                .param("size", size));
-        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-        System.out.println("테스트 : " + responseBody);
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets/{categoryName}", categoryName).param("page", page).param("size", size));
 
         // Then
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 response : " + responseBody);
+
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("성공"))
-                .andExpect(jsonPath("$.status").value(200));
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetList[1].assetId").value(19L))
+                .andExpect(jsonPath("$.data.assetList[1].wishlistId").doesNotExist())
+                .andExpect(jsonPath("$.data.assetList[1].cartId").doesNotExist());
     }
 
-    @DisplayName("카테고리별 에셋 조회 비로그인 성공")
+    @DisplayName("하위 카테고리별 에셋 조회 비로그인 성공")
     @Test
-    public void get_asset_list_with_pagination_by_category_test() throws Exception {
-        // given
+    public void find_asset_list_with_pagination_by_sub_category_test() throws Exception {
+        // Given
         String categoryName = "luxury";
+        String subCategoryName = "man";
         String page = "0";
         String size = "4";
 
-        // when
-        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets/{categoryName}",categoryName)
-                .param("page", page)
-                .param("size", size));
-        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-        System.out.println("테스트 : " + responseBody);
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets/{categoryName}/{subCategoryName}", categoryName, subCategoryName)
+                        .param("page", page)
+                        .param("size", size));
 
         // Then
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 response : " + responseBody);
+
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("성공"))
-                .andExpect(jsonPath("$.status").value(200));
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.totalElement").value(1L));
     }
 
     @DisplayName("하위 카테고리별 에셋 조회 로그인 성공")
     @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
     public void find_asset_list_with_user_id_and_pagination_by_sub_category_test() throws Exception {
-        // given
+        // Given
         String categoryName = "luxury";
         String subCategoryName = "man";
         String page = "0";
         String size = "28";
 
-        // when
-        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets/{categoryName}/{subCategoryName}", categoryName, subCategoryName)
-                .param("page", page)
-                .param("size", size));
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets/{categoryName}/{subCategoryName}", categoryName, subCategoryName)
+                        .param("page", page)
+                        .param("size", size));
+
+        // Then
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
         System.out.println("테스트 : " + responseBody);
 
-        // Then
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("성공"))
-                .andExpect(jsonPath("$.status").value(200));
-    }
-
-    @DisplayName("하위 카테고리별 에셋 조회 비로그인 성공")
-    @Test
-    public void find_asset_list_with_pagination_by_sub_category_test() throws Exception {
-        // given
-        String categoryName = "A";
-        String subCategoryName = "AA";
-        String page = "0";
-        String size = "4";
-
-        // when
-        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets/{categoryName}/{subCategoryName}", categoryName, subCategoryName)
-                .param("page", page)
-                .param("size", size));
-        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-        System.out.println("테스트 : " + responseBody);
-
-        // Then
-        resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.msg").value("성공"))
-                .andExpect(jsonPath("$.status").value(200));
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.totalElement").value(1L));
     }
 }

--- a/src/test/java/com/phoenix/assetbe/controller/CategoryControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/CategoryControllerTest.java
@@ -53,17 +53,19 @@ public class CategoryControllerTest {
     @DisplayName("카테고리별 이름,에셋수,태그리스트")
     @Test
     public void get_category_list_test() throws Exception {
-        //given
+        // Given
 
-        // when
+        // When
         ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get("/assets/count"));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
         System.out.println("테스트 : " + responseBody);
 
-        //then
+        // Then
         resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("성공"))
-                .andExpect(jsonPath("$.status").value(200));
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.categoryList[0].categoryName").value("cute"))
+                .andExpect(jsonPath("$.data.categoryList[0].categoryCount").value(6));
     }
 }

--- a/src/test/java/com/phoenix/assetbe/controller/ReviewControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/ReviewControllerTest.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,219 +42,250 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Transactional
 public class ReviewControllerTest {
-//
-//    private DummyEntity dummy = new DummyEntity();
-//
-//    @Autowired
-//    private MyTestSetUp myTestSetUp;
-//    @Autowired
-//    private MockMvc mockMvc;
-//    @Autowired
-//    private EntityManager em;
-//
-//    @Autowired
-//    private ObjectMapper om;
-//    @Autowired
-//    private AssetRepository assetRepository;
-//
-//    @BeforeEach
-//    public void setUp() throws Exception {
-//        List<User> userList = myTestSetUp.saveUser();
-//        List<Asset> assetList = myTestSetUp.saveAsset();
-//
-//        myTestSetUp.saveUserScenario(userList, assetList);
-//        myTestSetUp.saveCategoryAndSubCategoryAndTag(assetList);
-//    }
-//
-//    @DisplayName("리뷰보기 비로그인유저 성공")
-//    @Test
-//    public void get_reviews_test() throws Exception {
-//        // given
-//        Long id = 1L; // 에셋 id
-//
-//        // when
-//        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-//                .get("/assets/{id}/reviews",id));
-//        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-//        System.out.println("테스트 : " + responseBody);
-//
-//        // Then
-//        resultActions.andExpect(status().isOk())
-//                .andExpect(jsonPath("$.msg").value("성공"))
-//                .andExpect(jsonPath("$.status").value(200))
-//                .andExpect(jsonPath("$.data.hasAsset").value(false))
-//                .andExpect(jsonPath("$.data.hasReview").value(false))
-//                .andExpect(jsonPath("$.data.hasWishlist").value(false));
-//    }
-//
-//    @DisplayName("리뷰보기 로그인유저 성공")
-//    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-//    @Test
-//    public void get_reviews_with_user_test() throws Exception {
-//        // given
-//        Long id = 1L; // 에셋 id
-//
-//        // when
-//        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-//                .get("/assets/{id}/reviews",id));
-//        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-//        System.out.println("테스트 : " + responseBody);
-//
-//        // Then
-//        resultActions.andExpect(status().isOk())
-//                .andExpect(jsonPath("$.msg").value("성공"))
-//                .andExpect(jsonPath("$.status").value(200));
-//    }
-//
-//    @DisplayName("리뷰작성 성공")
-//    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-//    @Test
-//    public void add_review_test() throws Exception {
-//        // given
-//        Long id = 1L; // 에셋 id
-//        Long userId = 2L;
-//        ReviewRequest.ReviewInDTO addReviewInDTO =
-//                new ReviewRequest.ReviewInDTO(userId, 1D, "테스트입니다.");
-//        System.out.println("테스트 request : " + om.writeValueAsString(addReviewInDTO));
-//
-//        // when
-//        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-//                .post("/s/assets/{id}/reviews",id)
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(om.writeValueAsString(addReviewInDTO)));
-//        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-//        System.out.println("테스트 : " + responseBody);
-//
-//        // Then
-//        resultActions.andExpect(status().isOk())
-//                .andExpect(jsonPath("$.msg").value("성공"))
-//                .andExpect(jsonPath("$.status").value(200));
-//
-//        Asset assetPS = assetRepository.findById(id).orElseThrow(
-//                () -> new Exception400("id", "잘못된 요청")
-//        );
-//
-//        System.out.println("ReviewCount: "+assetPS.getReviewCount());
-//        System.out.println("Asset Rating: "+assetPS.getRating());
-//
-//    }
-//
-//    @DisplayName("리뷰작성 실패 에셋구매X")
-//    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-//    @Test
-//    public void add_review_fail_hasAsset_false_test() throws Exception {
-//        // given
-//        Long id = 2L; // 에셋 id
-//        Long userId = 4L;
-//        ReviewRequest.ReviewInDTO addReviewInDTO =
-//                new ReviewRequest.ReviewInDTO(userId, 4D, "테스트입니다.");
-//
-//        // when
-//        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-//                .post("/s/assets/{id}/reviews",id)
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(om.writeValueAsString(addReviewInDTO)));
-//        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-//        System.out.println("테스트 : " + responseBody);
-//
-//        // Then
-//        resultActions.andExpect(status().isForbidden())
-//                .andExpect(jsonPath("$.status").value("403"))
-//                .andExpect(jsonPath("$.msg").value("forbidden"))
-//                .andExpect(jsonPath("$.data").value("이 에셋을 구매하지 않았습니다. "));
-//
-//
-//    }
-//
-//    @DisplayName("리뷰작성 실패 이미 리뷰 쓴 경우")
-//    @WithUserDetails(value = "user3@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-//    @Test
-//    public void add_review_fail_hasReview_true_test() throws Exception {
-//        // given
-//        Long id = 1L; // 에셋 id
-//        Long userId = 3L;
-//        ReviewRequest.ReviewInDTO addReviewInDTO =
-//                new ReviewRequest.ReviewInDTO(userId, 4D, "테스트입니다.");
-//
-//        // when
-//        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-//                .post("/s/assets/{id}/reviews",id)
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(om.writeValueAsString(addReviewInDTO)));
-//        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-//        System.out.println("테스트 : " + responseBody);
-//
-//        // Then
-//        resultActions.andExpect(status().isForbidden())
-//                .andExpect(jsonPath("$.status").value("403"))
-//                .andExpect(jsonPath("$.msg").value("forbidden"))
-//                .andExpect(jsonPath("$.data").value("이미 이 에셋의 리뷰를 작성하셨습니다. "));
-//    }
-//
-//    @DisplayName("리뷰수정 성공")
-//    @WithUserDetails(value = "user3@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-//    @Test
-//    public void update_review_test() throws Exception {
-//        // given
-//        Long assetId = 1L; // 에셋 id
-//        Long reviewId = 3L;
-//        Long userId = 3L;
-//        ReviewRequest.ReviewInDTO updateReviewInDTO =
-//                new ReviewRequest.ReviewInDTO(userId, 1D, "테스트입니다.");
-//
-//        // when
-//        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-//                .post("/s/assets/{assetid}/reviews/{reviewId}", assetId, reviewId)
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(om.writeValueAsString(updateReviewInDTO)));
-//        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-//        System.out.println("테스트 : " + responseBody);
-//
-//        // Then
-//        resultActions.andExpect(status().isOk())
-//                .andExpect(jsonPath("$.msg").value("성공"))
-//                .andExpect(jsonPath("$.status").value(200));
-//
-//        Asset assetPS = assetRepository.findById(assetId).orElseThrow(
-//                () -> new Exception400("assetId", "잘못된 요청입니다. ")
-//        );
-//        assertEquals(3L, assetPS.getReviewCount()); // 수정 후 ReviewCount는 변하지 않아야 한다.
-//        System.out.println("ReviewCount: "+assetPS.getReviewCount());
-//        System.out.println("Asset Rating: "+assetPS.getRating());
-//
-//    }
-//
-//    @DisplayName("리뷰삭제 성공")
-//    @WithUserDetails(value = "user3@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-//    @Test
-//    public void delete_review_test() throws Exception {
-//        // given
-//        Long assetId = 1L; // 에셋 id
-//        Long reviewId = 3L;
-//        Long userId = 3L;
-//        ReviewRequest.DeleteReviewInDTO deleteReviewInDTO =
-//                new ReviewRequest.DeleteReviewInDTO(userId);
-//
-//        // when
-//        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-//                .post("/s/assets/{assetId}/reviews/{reviewId}/delete", assetId, reviewId)
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(om.writeValueAsString(deleteReviewInDTO)));
-//        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-//        System.out.println("테스트 : " + responseBody);
-//
-//        // Then
-//        resultActions.andExpect(status().isOk())
-//                .andExpect(jsonPath("$.msg").value("성공"))
-//                .andExpect(jsonPath("$.status").value(200));
-//
-//        Asset assetPS = assetRepository.findById(assetId).orElseThrow(
-//                () -> new Exception400("assetId", "잘못된 요청입니다. ")
-//        );
-//        assertEquals(2L, assetPS.getReviewCount()); // 삭제 후 ReviewCount는 1 줄어든다.
-//        assertEquals(3.5D, assetPS.getRating());
-//        System.out.println("ReviewCount: "+assetPS.getReviewCount());
-//        System.out.println("Asset Rating: "+assetPS.getRating());
-//
-//    }
+
+    private DummyEntity dummy = new DummyEntity();
+
+    @Autowired
+    private MyTestSetUp myTestSetUp;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @Autowired
+    private AssetRepository assetRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MyAssetRepository myAssetRepository;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        List<User> userList = myTestSetUp.saveUser();
+        List<Asset> assetList = myTestSetUp.saveAsset();
+
+        myTestSetUp.saveUserScenario(userList, assetList);
+        myTestSetUp.saveCategoryAndSubCategoryAndTag(assetList);
+
+        User user1 = userRepository.findById(1L).orElseThrow();
+        User user3 = userRepository.findById(3L).orElseThrow();
+        Asset asset = Asset.builder().assetName("a").reviewCount(1L).rating(4D).status(true).build();
+        Review review = Review.builder().rating(4D).content("좋아요").user(user3).asset(asset).build();
+        MyAsset myAsset1 = MyAsset.builder().asset(asset).user(user3).build();
+        MyAsset myAsset2 = MyAsset.builder().asset(asset).user(user1).build();
+        assetRepository.save(asset);
+        reviewRepository.save(review);
+        myAssetRepository.saveAll(Arrays.asList(myAsset1, myAsset2));
+
+        em.clear();
+    }
+
+    @DisplayName("리뷰보기 비로그인유저 성공")
+    @Test
+    public void get_reviews_test() throws Exception {
+        // Given
+        Long id = 31L; // 에셋 id
+
+        // When
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .get("/assets/{id}/reviews",id));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.hasAsset").value(false))
+                .andExpect(jsonPath("$.data.hasReview").value(false))
+                .andExpect(jsonPath("$.data.hasWishlist").value(false));
+    }
+
+    @DisplayName("리뷰보기 로그인유저 성공")
+    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void get_reviews_with_user_test() throws Exception {
+        // Given
+        Long id = 31L; // 에셋 id
+
+        // When
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .get("/assets/{id}/reviews",id));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.hasReview").value(true));
+    }
+
+    @DisplayName("리뷰작성 성공")
+    @WithUserDetails(value = "유현주@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void add_review_test() throws Exception {
+        // Given
+        Long id = 31L; // 에셋 id
+        Long userId = 1L;
+        ReviewRequest.ReviewInDTO addReviewInDTO =
+                new ReviewRequest.ReviewInDTO(userId, 1D, "테스트입니다.");
+        System.out.println("테스트 request : " + om.writeValueAsString(addReviewInDTO));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .post("/s/assets/{id}/reviews",id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(addReviewInDTO)));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetId").value(31L))
+                .andExpect(jsonPath("$.data.reviewId").value(2L))
+                .andExpect(jsonPath("$.data.content").value("테스트입니다."))
+                .andExpect(jsonPath("$.data.reviewRating").value(1D))
+                .andExpect(jsonPath("$.data.assetRating").value(2.5D));
+
+        Asset assetPS = assetRepository.findById(id).orElseThrow(
+                () -> new Exception400("id", "잘못된 요청")
+        );
+        assertEquals(2L, assetPS.getReviewCount()); // 작성 후 ReviewCount는 증가한다.
+        System.out.println("ReviewCount: "+assetPS.getReviewCount());
+        System.out.println("AssetRating: "+assetPS.getRating());
+
+    }
+
+    @DisplayName("리뷰작성 실패 : 에셋 구매 안함")
+    @WithUserDetails(value = "송재근@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void add_review_fail_hasAsset_false_test() throws Exception {
+        // Given
+        Long id = 31L; // 에셋 id
+        Long userId = 2L;
+        ReviewRequest.ReviewInDTO addReviewInDTO =
+                new ReviewRequest.ReviewInDTO(userId, 4D, "테스트입니다.");
+
+        // When
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .post("/s/assets/{id}/reviews",id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(addReviewInDTO)));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value("403"))
+                .andExpect(jsonPath("$.msg").value("forbidden"))
+                .andExpect(jsonPath("$.data").value("이 에셋을 구매하지 않았습니다. "));
+    }
+
+    @DisplayName("리뷰작성 실패 : 이전에 리뷰 작성함")
+    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void add_review_fail_hasReview_true_test() throws Exception {
+        // Given
+        Long id = 31L; // 에셋 id
+        Long userId = 3L;
+        ReviewRequest.ReviewInDTO addReviewInDTO =
+                new ReviewRequest.ReviewInDTO(userId, 4D, "테스트입니다.");
+
+        // When
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .post("/s/assets/{id}/reviews",id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(addReviewInDTO)));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value("403"))
+                .andExpect(jsonPath("$.msg").value("forbidden"))
+                .andExpect(jsonPath("$.data").value("이미 이 에셋의 리뷰를 작성하셨습니다. "));
+    }
+
+    @DisplayName("리뷰수정 성공")
+    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void update_review_test() throws Exception {
+        // Given
+        Long assetId = 31L; // 에셋 id
+        Long reviewId = 1L;
+        Long userId = 3L;
+        ReviewRequest.ReviewInDTO updateReviewInDTO =
+                new ReviewRequest.ReviewInDTO(userId, 3D, "테스트입니다.");
+
+        // When
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .post("/s/assets/{assetid}/reviews/{reviewId}", assetId, reviewId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(updateReviewInDTO)));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetId").value(31L))
+                .andExpect(jsonPath("$.data.reviewId").value(1L))
+                .andExpect(jsonPath("$.data.content").value("테스트입니다."))
+                .andExpect(jsonPath("$.data.reviewRating").value(3D));
+
+        Asset assetPS = assetRepository.findById(assetId).orElseThrow(
+                () -> new Exception400("assetId", "잘못된 요청입니다. ")
+        );
+        assertEquals(1L, assetPS.getReviewCount()); // 수정 후 ReviewCount는 변하지 않아야 한다.
+        System.out.println("ReviewCount: "+assetPS.getReviewCount());
+        System.out.println("Asset Rating: "+assetPS.getRating());
+
+    }
+
+    @DisplayName("리뷰삭제 성공")
+    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void delete_review_test() throws Exception {
+        // Given
+        Long assetId = 31L; // 에셋 id
+        Long reviewId = 1L;
+        Long userId = 3L;
+        ReviewRequest.DeleteReviewInDTO deleteReviewInDTO =
+                new ReviewRequest.DeleteReviewInDTO(userId);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .post("/s/assets/{assetId}/reviews/{reviewId}/delete", assetId, reviewId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(deleteReviewInDTO)));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200));
+
+        Asset assetPS = assetRepository.findById(assetId).orElseThrow(
+                () -> new Exception400("assetId", "잘못된 요청입니다. ")
+        );
+        assertEquals(0L, assetPS.getReviewCount()); // 삭제 후 ReviewCount는 1 줄어든다.
+        assertEquals(0D, assetPS.getRating());
+        System.out.println("ReviewCount: "+assetPS.getReviewCount());
+        System.out.println("Asset Rating: "+assetPS.getRating());
+    }
 }

--- a/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
+++ b/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 @DisplayName("에셋 레포지토리 TEST")
 @ActiveProfiles("test")
@@ -50,16 +49,16 @@ public class AssetQueryRepositoryTest {
 
     @Test
     public void find_assets_test() {
-        //Given
+        // Given
         Long userId = 1L;
         int page = 0;
         int size = 3;
         Pageable pageable = PageRequest.of(page, size, Sort.by("releaseDate").descending());
 
+        // When
         Page<AssetResponse.AssetsOutDTO.AssetDetail> result = assetQueryRepository.findAssetsWithUserIdAndPaging(userId, pageable);
 
-        //then
+        // Then
         assertThat(result.getContent().size(), is(3));
-
     }
 }

--- a/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
+++ b/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
@@ -60,6 +60,6 @@ public class AssetQueryRepositoryTest {
         Page<AssetResponse.AssetListOutDTO.AssetOutDTO> result = assetQueryRepository.findAssetListWithUserIdAndPaging(userId, pageable);
 
         // Then
-        assertThat(result.getContent().size(), is(2));
+        assertThat(result.getContent().size(), is(3));
     }
 }

--- a/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
+++ b/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
@@ -56,7 +56,7 @@ public class AssetQueryRepositoryTest {
         Pageable pageable = PageRequest.of(page, size, Sort.by("releaseDate").descending());
 
         // When
-        Page<AssetResponse.AssetsOutDTO.AssetDetail> result = assetQueryRepository.findAssetsWithUserIdAndPaging(userId, pageable);
+        Page<AssetResponse.AssetListOutDTO.AssetDetail> result = assetQueryRepository.findAssetListWithUserIdAndPaging(userId, pageable);
 
         // Then
         assertThat(result.getContent().size(), is(3));

--- a/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
+++ b/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
@@ -3,6 +3,7 @@ package com.phoenix.assetbe.model.asset;
 import com.phoenix.assetbe.core.config.MyTestSetUp;
 import com.phoenix.assetbe.core.dummy.DummyEntity;
 import com.phoenix.assetbe.dto.asset.AssetResponse;
+import com.phoenix.assetbe.model.cs.QnaRepository;
 import com.phoenix.assetbe.model.user.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -56,9 +57,9 @@ public class AssetQueryRepositoryTest {
         Pageable pageable = PageRequest.of(page, size, Sort.by("releaseDate").descending());
 
         // When
-        Page<AssetResponse.AssetListOutDTO.AssetDetail> result = assetQueryRepository.findAssetListWithUserIdAndPaging(userId, pageable);
+        Page<AssetResponse.AssetListOutDTO.AssetOutDTO> result = assetQueryRepository.findAssetListWithUserIdAndPaging(userId, pageable);
 
         // Then
-        assertThat(result.getContent().size(), is(3));
+        assertThat(result.getContent().size(), is(2));
     }
 }


### PR DESCRIPTION
## Motivation

- 에셋 수 카운트 방법 수정
- 리뷰 엔티티 메서드 수정
- 카테고리별, 서브카테고리별 리펙토링
- 에셋 조회시 에셋의 status가 true인 조건 추가
- 에셋 상세 previewList 추가
- 리뷰, 에셋 서비스에 예외발생조건 추가
- 에셋, 리뷰 DTO 수정

resolved #35 