### PR TITLE
feat : #17 에셋 검색

### DIFF
--- a/src/main/java/com/phoenix/assetbe/controller/AssetController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/AssetController.java
@@ -13,7 +13,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -77,6 +80,18 @@ public class AssetController {
         AssetResponse.AssetListOutDTO assetListOutDTO =
                 assetService.getAssetListBySubCategoryService(categoryName, subCategoryName, pageable, myUserDetails);
         ResponseDTO<?> responseDTO = new ResponseDTO<>(assetListOutDTO);
+        return ResponseEntity.ok().body(responseDTO);
+    }
+
+    @GetMapping("/assets/search")
+    public ResponseEntity<?> getAssetListBySearch(
+            @RequestParam(value = "keyword", required = false) List<String> keyword,
+            @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal MyUserDetails myUserDetails) {
+
+        AssetResponse.AssetsOutDTO assetsOutDTO =
+                assetService.getAssetListBySearchService(keyword, pageable, myUserDetails);
+        ResponseDTO<?> responseDTO = new ResponseDTO<>(assetsOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
 }

--- a/src/main/java/com/phoenix/assetbe/controller/AssetController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/AssetController.java
@@ -89,7 +89,7 @@ public class AssetController {
             @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal MyUserDetails myUserDetails) {
 
-        AssetResponse.AssetsOutDTO assetsOutDTO =
+        AssetResponse.AssetListOutDTO assetsOutDTO =
                 assetService.getAssetListBySearchService(keyword, pageable, myUserDetails);
         ResponseDTO<?> responseDTO = new ResponseDTO<>(assetsOutDTO);
         return ResponseEntity.ok().body(responseDTO);

--- a/src/main/java/com/phoenix/assetbe/controller/AssetController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/AssetController.java
@@ -57,11 +57,12 @@ public class AssetController {
     @GetMapping("/assets/{categoryName}")
     public ResponseEntity<?> getAssetListByCategory(
             @PathVariable String categoryName,
+            @RequestParam(value = "keyword", required = false) List<String> keywordList,
             @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal MyUserDetails myUserDetails) {
 
         AssetResponse.AssetListOutDTO assetListOutDTO =
-                assetService.getAssetListByCategoryService(categoryName, pageable, myUserDetails);
+                assetService.getAssetListByCategoryService(categoryName, keywordList, pageable, myUserDetails);
         ResponseDTO<?> responseDTO = new ResponseDTO<>(assetListOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
@@ -74,15 +75,19 @@ public class AssetController {
     public ResponseEntity<?> getAssetListBySubCategory(
             @PathVariable String categoryName,
             @PathVariable String subCategoryName,
+            @RequestParam(value = "keyword", required = false) List<String> keywordList,
             @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal MyUserDetails myUserDetails) {
 
         AssetResponse.AssetListOutDTO assetListOutDTO =
-                assetService.getAssetListBySubCategoryService(categoryName, subCategoryName, pageable, myUserDetails);
+                assetService.getAssetListBySubCategoryService(categoryName, subCategoryName, keywordList, pageable, myUserDetails);
         ResponseDTO<?> responseDTO = new ResponseDTO<>(assetListOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
 
+    /**
+     * 키워드로 에셋 검색
+     */
     @GetMapping("/assets/search")
     public ResponseEntity<?> getAssetListBySearch(
             @RequestParam(value = "keyword", required = false) List<String> keywordList,

--- a/src/main/java/com/phoenix/assetbe/controller/AssetController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/AssetController.java
@@ -57,12 +57,13 @@ public class AssetController {
     @GetMapping("/assets/{categoryName}")
     public ResponseEntity<?> getAssetListByCategory(
             @PathVariable String categoryName,
+            @RequestParam(value = "tag", required = false) List<String> tagList,
             @RequestParam(value = "keyword", required = false) List<String> keywordList,
             @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal MyUserDetails myUserDetails) {
 
         AssetResponse.AssetListOutDTO assetListOutDTO =
-                assetService.getAssetListByCategoryService(categoryName, keywordList, pageable, myUserDetails);
+                assetService.getAssetListByCategoryService(categoryName, tagList, keywordList, pageable, myUserDetails);
         ResponseDTO<?> responseDTO = new ResponseDTO<>(assetListOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
@@ -75,12 +76,13 @@ public class AssetController {
     public ResponseEntity<?> getAssetListBySubCategory(
             @PathVariable String categoryName,
             @PathVariable String subCategoryName,
+            @RequestParam(value = "tag", required = false) List<String> tagList,
             @RequestParam(value = "keyword", required = false) List<String> keywordList,
             @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal MyUserDetails myUserDetails) {
 
         AssetResponse.AssetListOutDTO assetListOutDTO =
-                assetService.getAssetListBySubCategoryService(categoryName, subCategoryName, keywordList, pageable, myUserDetails);
+                assetService.getAssetListBySubCategoryService(categoryName, subCategoryName, tagList, keywordList, pageable, myUserDetails);
         ResponseDTO<?> responseDTO = new ResponseDTO<>(assetListOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }

--- a/src/main/java/com/phoenix/assetbe/controller/AssetController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/AssetController.java
@@ -85,12 +85,12 @@ public class AssetController {
 
     @GetMapping("/assets/search")
     public ResponseEntity<?> getAssetListBySearch(
-            @RequestParam(value = "keyword", required = false) List<String> keyword,
+            @RequestParam(value = "keyword", required = false) List<String> keywordList,
             @PageableDefault(size = 28, sort = "releaseDate", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal MyUserDetails myUserDetails) {
 
         AssetResponse.AssetListOutDTO assetsOutDTO =
-                assetService.getAssetListBySearchService(keyword, pageable, myUserDetails);
+                assetService.getAssetListBySearchService(keywordList, pageable, myUserDetails);
         ResponseDTO<?> responseDTO = new ResponseDTO<>(assetsOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }

--- a/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/asset/AssetResponse.java
@@ -69,6 +69,7 @@ public class AssetResponse {
             this.totalElement = assetList.getTotalElements();
         }
 
+
         @NoArgsConstructor
         @AllArgsConstructor
         @Getter @Setter

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
@@ -2,9 +2,7 @@ package com.phoenix.assetbe.model.asset;
 
 import com.phoenix.assetbe.dto.asset.AssetResponse;
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -13,13 +11,13 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.phoenix.assetbe.model.asset.QAsset.asset;
 import static com.phoenix.assetbe.model.asset.QAssetCategory.assetCategory;
 import static com.phoenix.assetbe.model.asset.QAssetTag.assetTag;
 import static com.phoenix.assetbe.model.asset.QCategory.category;
 import static com.phoenix.assetbe.model.asset.QSubCategory.subCategory;
+import static com.phoenix.assetbe.model.asset.QTag.tag;
 import static com.phoenix.assetbe.model.cart.QCart.cart;
 import static com.phoenix.assetbe.model.wish.QWishList.wishList;
 
@@ -30,407 +28,13 @@ public class AssetQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     /**
-     * 개별 에셋, 로그인 유저, 페이지네이션
+     * 로그인 유저
+     * 개별 에셋
+     * 에셋 검색
+     * 페이지네이션
      */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithUserAndPage(Long userId, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
-                .select(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
-                        asset.id,
-                        asset.assetName,
-                        asset.price,
-                        asset.discount,
-                        asset.discountPrice,
-                        asset.releaseDate,
-                        asset.thumbnailUrl,
-                        asset.rating,
-                        asset.reviewCount,
-                        asset.wishCount,
-                        wishList.id,
-                        cart.id)
-                )
-                .from(asset)
-                .leftJoin(wishList).on(wishList.asset.id.eq(asset.id)).on(wishList.user.id.eq(userId))
-                .leftJoin(cart).on(cart.asset.id.eq(asset.id)).on(cart.user.id.eq(userId))
-                .where(asset.status.eq(true))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(assetSort(pageable))
-                .fetch();
-
-        Long totalCount = queryFactory.select(asset.id.countDistinct())
-                .from(asset)
-                .where(asset.status.eq(true))
-                .fetchOne();
-
-        return new PageImpl<>(result, pageable, totalCount);
-    }
-
-    /**
-     * 개별 에셋, 비로그인 유저, 페이지네이션
-     */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithPage(Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
-                .select(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
-                        asset.id,
-                        asset.assetName,
-                        asset.price,
-                        asset.discount,
-                        asset.discountPrice,
-                        asset.releaseDate,
-                        asset.thumbnailUrl,
-                        asset.rating,
-                        asset.reviewCount,
-                        asset.wishCount)
-                )
-                .from(asset)
-                .where(asset.status.eq(true))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(assetSort(pageable))
-                .fetch();
-
-        Long totalCount = queryFactory.select(asset.id.countDistinct())
-                .from(asset)
-                .where(asset.status.eq(true))
-                .fetchOne();
-
-        return new PageImpl<>(result, pageable, totalCount);
-    }
-
-    /**
-     * 카테고리별 에셋 조회, 로그인 유저, 페이지네이션
-     */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithUserAndPageByCategory(
-            Long userId, String categoryName, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
-                        asset.id,
-                        asset.assetName,
-                        asset.price,
-                        asset.discount,
-                        asset.discountPrice,
-                        asset.releaseDate,
-                        asset.thumbnailUrl,
-                        asset.rating,
-                        asset.reviewCount,
-                        asset.wishCount,
-                        wishList.id,
-                        cart.id)
-                )
-                .from(asset)
-                .innerJoin(assetCategory).on(assetCategory.asset.eq(asset))
-                .innerJoin(category).on(assetCategory.category.eq(category))
-                .leftJoin(wishList).on(wishList.asset.eq(asset)).on(wishList.user.id.eq(userId))
-                .leftJoin(cart).on(cart.asset.eq(asset)).on(cart.user.id.eq(userId))
-                .where(category.categoryName.eq(categoryName).and(asset.status.eq(true)))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(assetSort(pageable))
-                .fetch();
-
-        Long totalCount = queryFactory.select(asset.id.countDistinct())
-                .from(asset)
-                .innerJoin(assetCategory).on(assetCategory.asset.eq(asset))
-                .innerJoin(category).on(category.eq(assetCategory.category))
-                .where(category.categoryName.eq(categoryName).and(asset.status.eq(true)))
-                .fetchOne();
-
-        return new PageImpl<>(result, pageable, totalCount);
-
-    }
-
-    /**
-     * 카테고리별 에셋 조회, 비로그인 유저, 페이지네이션
-     */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithPageByCategory(
-            String categoryName, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
-                        asset.id,
-                        asset.assetName,
-                        asset.price,
-                        asset.discount,
-                        asset.discountPrice,
-                        asset.releaseDate,
-                        asset.thumbnailUrl,
-                        asset.rating,
-                        asset.reviewCount,
-                        asset.wishCount)
-                )
-                .from(asset)
-                .innerJoin(assetCategory).on(assetCategory.asset.eq(asset))
-                .innerJoin(category).on(assetCategory.category.eq(category))
-                .where(category.categoryName.eq(categoryName).and(asset.status.eq(true)))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(assetSort(pageable))
-                .fetch();
-
-        Long totalCount = queryFactory.select(asset.id.countDistinct())
-                .from(asset)
-                .innerJoin(assetCategory).on(assetCategory.asset.eq(asset))
-                .innerJoin(category).on(category.eq(assetCategory.category))
-                .where(category.categoryName.eq(categoryName).and(asset.status.eq(true)))
-                .fetchOne();
-
-        return new PageImpl<>(result, pageable, totalCount);
-
-    }
-
-    /**
-     * 카테고리별 에셋 검색, 로그인 유저, 페이지네이션
-     */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithUserAndPageAndSearchByCategory(
-            Long userId, String categoryName, List<String> keywordList, Pageable pageable){
-
-        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
-                        asset.id,
-                        asset.assetName,
-                        asset.price,
-                        asset.discount,
-                        asset.discountPrice,
-                        asset.releaseDate,
-                        asset.thumbnailUrl,
-                        asset.rating,
-                        asset.reviewCount,
-                        asset.wishCount,
-                        wishList.id,
-                        cart.id)
-                )
-                .from(asset)
-                .innerJoin(assetCategory).on(assetCategory.asset.id.eq(asset.id))
-                .innerJoin(category).on(assetCategory.category.id.eq(category.id))
-                .where(category.categoryName.eq(categoryName), asset.status.eq(true), totalCondition(keywordList))
-                .leftJoin(wishList).on(wishList.asset.id.eq(asset.id).and(wishList.user.id.eq(userId)))
-                .leftJoin(cart).on(cart.asset.id.eq(asset.id).and(cart.user.id.eq(userId)))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(assetSortByIncludedKeywordCount(keywordList).desc(), assetSort(pageable))
-                .fetch();
-
-        Long totalCount = queryFactory.select(asset.id.countDistinct())
-                .from(asset)
-                .innerJoin(assetCategory).on(assetCategory.asset.id.eq(asset.id))
-                .innerJoin(category).on(assetCategory.category.id.eq(category.id))
-                .where(category.categoryName.eq(categoryName), asset.status.eq(true), totalCondition(keywordList))
-                .fetchOne();
-
-        return new PageImpl<>(result, pageable, totalCount);
-    }
-
-    /**
-     * 카테고리별 에셋 검색, 비로그인 유저, 페이지네이션
-     */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithPageAndSearchByCategory(
-            String categoryName, List<String> keywordList,Pageable pageable){
-
-        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
-                        asset.id,
-                        asset.assetName,
-                        asset.price,
-                        asset.discount,
-                        asset.discountPrice,
-                        asset.releaseDate,
-                        asset.thumbnailUrl,
-                        asset.rating,
-                        asset.reviewCount,
-                        asset.wishCount)
-                )
-                .from(asset)
-                .innerJoin(assetCategory).on(assetCategory.asset.id.eq(asset.id))
-                .innerJoin(category).on(assetCategory.category.id.eq(category.id))
-                .where(category.categoryName.eq(categoryName), asset.status.eq(true), totalCondition(keywordList))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(assetSortByIncludedKeywordCount(keywordList).desc(), assetSort(pageable))
-                .fetch();
-
-        Long totalCount = queryFactory.select(asset.id.countDistinct())
-                .from(asset)
-                .innerJoin(assetCategory).on(assetCategory.asset.id.eq(asset.id))
-                .innerJoin(category).on(assetCategory.category.id.eq(category.id))
-                .where(category.categoryName.eq(categoryName), asset.status.eq(true), totalCondition(keywordList))
-                .fetchOne();
-
-        return new PageImpl<>(result, pageable, totalCount);
-
-    }
-
-    /**
-     * 서브카테고리별 에셋 조회, 로그인 유저, 페이지네이션
-     */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithUserAndPageBySubCategory(
-            Long userId, String categoryName, String subCategoryName, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
-                        asset.id,
-                        asset.assetName,
-                        asset.price,
-                        asset.discount,
-                        asset.discountPrice,
-                        asset.releaseDate,
-                        asset.thumbnailUrl,
-                        asset.rating,
-                        asset.reviewCount,
-                        asset.wishCount,
-                        wishList.id,
-                        cart.id)
-                )
-                .from(asset)
-                .innerJoin(assetTag).on(asset.eq(assetTag.asset))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id).and(category.categoryName.eq(categoryName)))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id).and(subCategory.subCategoryName.eq(subCategoryName)))
-                .leftJoin(wishList).on(wishList.user.id.eq(userId).and(wishList.asset.eq(asset)))
-                .leftJoin(cart).on(cart.user.id.eq(userId).and(cart.asset.eq(asset)))
-                .where(asset.status.eq(true))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(assetSort(pageable))
-                .fetch();
-
-        Long totalCount = queryFactory.select(asset.id.countDistinct())
-                .from(asset)
-                .innerJoin(assetTag).on(asset.eq(assetTag.asset))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id).and(category.categoryName.eq(categoryName)))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id).and(subCategory.subCategoryName.eq(subCategoryName)))
-                .where(asset.status.eq(true))
-                .fetchOne();
-
-        return new PageImpl<>(result, pageable, totalCount);
-
-    }
-
-    /**
-     * 서브카테고리별 에셋 조회, 비로그인 유저, 페이지네이션
-     */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithPageBySubCategory(
-            String categoryName, String subCategoryName, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
-                        asset.id,
-                        asset.assetName,
-                        asset.price,
-                        asset.discount,
-                        asset.discountPrice,
-                        asset.releaseDate,
-                        asset.thumbnailUrl,
-                        asset.rating,
-                        asset.reviewCount,
-                        asset.wishCount)
-                )
-                .from(asset)
-                .innerJoin(assetTag).on(asset.eq(assetTag.asset))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id).and(category.categoryName.eq(categoryName)))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id).and(subCategory.subCategoryName.eq(subCategoryName)))
-                .where(asset.status.eq(true))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(assetSort(pageable))
-                .fetch();
-
-        Long totalCount = queryFactory.select(asset.id.countDistinct())
-                .from(asset)
-                .innerJoin(assetTag).on(asset.eq(assetTag.asset))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id).and(category.categoryName.eq(categoryName)))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id).and(subCategory.subCategoryName.eq(subCategoryName)))
-                .where(asset.status.eq(true))
-                .fetchOne();
-
-        return new PageImpl<>(result, pageable, totalCount);
-
-    }
-
-    /**
-     * 서브카테고리별 에셋 검색, 로그인 유저, 페이지네이션
-     */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithUserAndPageAndSearchBySubCategory(
-            Long userId, String categoryName, String subCategoryName, List<String> keywordList, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
-                        asset.id,
-                        asset.assetName,
-                        asset.price,
-                        asset.discount,
-                        asset.discountPrice,
-                        asset.releaseDate,
-                        asset.thumbnailUrl,
-                        asset.rating,
-                        asset.reviewCount,
-                        asset.wishCount,
-                        wishList.id,
-                        cart.id)
-                )
-                .from(asset)
-                .innerJoin(assetTag).on(asset.eq(assetTag.asset))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
-                .leftJoin(wishList).on(wishList.user.id.eq(userId).and(wishList.asset.eq(asset)))
-                .leftJoin(cart).on(cart.user.id.eq(userId).and(cart.asset.eq(asset)))
-                .where(category.categoryName.eq(categoryName), subCategory.subCategoryName.eq(subCategoryName), asset.status.eq(true), totalCondition(keywordList))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(assetSortByIncludedKeywordCount(keywordList).desc(), assetSort(pageable))
-                .fetch();
-
-        Long totalCount = queryFactory.select(asset.id.countDistinct())
-                .from(asset)
-                .innerJoin(assetTag).on(asset.eq(assetTag.asset))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
-                .where(category.categoryName.eq(categoryName), subCategory.subCategoryName.eq(subCategoryName), asset.status.eq(true), totalCondition(keywordList))
-                .fetchOne();
-
-        return new PageImpl<>(result, pageable, totalCount);
-
-    }
-
-    /**
-     * 서브카테고리별 에셋 검색, 비로그인 유저, 페이지네이션
-     */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithPageAndSearchBySubCategory(
-            String categoryName, String subCategoryName, List<String> keywordList, Pageable pageable){
-        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
-                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
-                        asset.id,
-                        asset.assetName,
-                        asset.price,
-                        asset.discount,
-                        asset.discountPrice,
-                        asset.releaseDate,
-                        asset.thumbnailUrl,
-                        asset.rating,
-                        asset.reviewCount,
-                        asset.wishCount)
-                )
-                .from(asset)
-                .innerJoin(assetTag).on(asset.eq(assetTag.asset))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
-                .where(category.categoryName.eq(categoryName), subCategory.subCategoryName.eq(subCategoryName), asset.status.eq(true), totalCondition(keywordList))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(assetSortByIncludedKeywordCount(keywordList).desc(), assetSort(pageable))
-                .fetch();
-
-        Long totalCount = queryFactory.select(asset.id.countDistinct())
-                .from(asset)
-                .innerJoin(assetTag).on(asset.eq(assetTag.asset))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
-                .where(category.categoryName.eq(categoryName), subCategory.subCategoryName.eq(subCategoryName), asset.status.eq(true), totalCondition(keywordList))
-                .fetchOne();
-
-        return new PageImpl<>(result, pageable, totalCount);
-
-    }
-
-    /**
-     * 에셋 검색, 로그인 유저, 페이지네이션
-     */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithUserAndPageBySearch(
-            Long userId, List<String> keywordList,Pageable pageable){
+    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithUser(
+            Long userId, List<String> keywordList, Pageable pageable){
 
         List<AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
                 .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
@@ -450,7 +54,7 @@ public class AssetQueryRepository {
                 .from(asset)
                 .leftJoin(wishList).on(wishList.user.id.eq(userId).and(wishList.asset.eq(asset)))
                 .leftJoin(cart).on(cart.user.id.eq(userId).and(cart.asset.eq(asset)))
-                .where(asset.status.eq(true), totalCondition(keywordList))
+                .where(asset.status.eq(true), containKeyword(keywordList))
                 .orderBy(assetSortByIncludedKeywordCount(keywordList).desc(), assetSort(pageable))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -458,16 +62,19 @@ public class AssetQueryRepository {
 
         Long totalCount = queryFactory.select(asset.count())
                 .from(asset)
-                .where(asset.status.eq(true), totalCondition(keywordList))
+                .where(asset.status.eq(true), containKeyword(keywordList))
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, totalCount);
     }
 
     /**
-     * 에셋 검색, 비로그인 유저, 페이지네이션
+     * 로그인 유저
+     * 개별 에셋
+     * 에셋 검색
+     * 페이지네이션
      */
-    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithPageBySearch(
+    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetList(
             List<String> keywordList, Pageable pageable){
 
         List<AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
@@ -484,24 +91,114 @@ public class AssetQueryRepository {
                         asset.wishCount)
                 )
                 .from(asset)
-                .where(asset.status.eq(true), totalCondition(keywordList))
+                .where(asset.status.eq(true), containKeyword(keywordList))
                 .orderBy(assetSortByIncludedKeywordCount(keywordList).desc(), assetSort(pageable))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        Long totalCount = queryFactory.select(asset.count())
+        Long totalCount = queryFactory.select(asset.id.countDistinct())
                 .from(asset)
-                .where(asset.status.eq(true), totalCondition(keywordList))
+                .where(asset.status.eq(true), containKeyword(keywordList))
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, totalCount);
     }
 
-    public Optional<Asset> findById(Long userId) {
-        return Optional.ofNullable(queryFactory.selectFrom(asset)
-                .where(asset.status.eq(true).and(asset.id.eq(userId)))
-                .fetchOne());
+    /**
+     * 로그인 유저
+     * 카테고리별 에셋 조회 및 검색
+     * 서브카테고리별 에셋 조회 및 검색
+     * 검색조건: tag, keyword
+     * 페이지네이션
+     */
+    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListWithUserByCategoryOrSubCategory(
+            Long userId, String categoryName, String subCategoryName, List<String> tagList, List<String> keywordList, Pageable pageable){
+
+        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
+                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
+                        asset.id,
+                        asset.assetName,
+                        asset.price,
+                        asset.discount,
+                        asset.discountPrice,
+                        asset.releaseDate,
+                        asset.thumbnailUrl,
+                        asset.rating,
+                        asset.reviewCount,
+                        asset.wishCount,
+                        wishList.id,
+                        cart.id)
+                )
+                .from(asset)
+                .innerJoin(assetTag).on(asset.id.eq(assetTag.asset.id))
+                .innerJoin(category).on(category.id.eq(assetTag.category.id))
+                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
+                .innerJoin(tag).on(tag.id.eq(assetTag.tag.id))
+                .leftJoin(wishList).on(wishList.user.id.eq(userId).and(wishList.asset.eq(asset)))
+                .leftJoin(cart).on(cart.user.id.eq(userId).and(cart.asset.eq(asset)))
+                .where(asset.status.eq(true), categoryNameEq(categoryName), subCategoryNameEq(subCategoryName), tagListEq(tagList), containKeyword(keywordList))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(assetSortByIncludedKeywordCount(keywordList).desc(), assetSort(pageable))
+                .fetch();
+
+        Long totalCount = queryFactory.select(asset.id.countDistinct())
+                .from(asset)
+                .innerJoin(assetTag).on(asset.id.eq(assetTag.asset.id))
+                .innerJoin(category).on(category.id.eq(assetTag.category.id))
+                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
+                .innerJoin(tag).on(tag.id.eq(assetTag.tag.id))
+                .where(asset.status.eq(true), categoryNameEq(categoryName), subCategoryNameEq(subCategoryName), tagListEq(tagList), containKeyword(keywordList))
+                .fetchOne();
+
+        return new PageImpl<>(result, pageable, totalCount);
+    }
+
+    /**
+     * 비로그인 유저
+     * 카테고리별 에셋 조회 및 검색
+     * 서브카테고리별 에셋 조회 및 검색
+     * 검색조건: tag, keyword
+     * 페이지네이션
+     */
+    public Page<AssetResponse.AssetListOutDTO.AssetOutDTO> findAssetListByCategoryOrSubCategory(
+            String categoryName, String subCategoryName, List<String> tagList, List<String> keywordList, Pageable pageable){
+
+        List <AssetResponse.AssetListOutDTO.AssetOutDTO> result = queryFactory
+                .selectDistinct(Projections.constructor(AssetResponse.AssetListOutDTO.AssetOutDTO.class,
+                        asset.id,
+                        asset.assetName,
+                        asset.price,
+                        asset.discount,
+                        asset.discountPrice,
+                        asset.releaseDate,
+                        asset.thumbnailUrl,
+                        asset.rating,
+                        asset.reviewCount,
+                        asset.wishCount)
+                )
+                .from(asset)
+                .innerJoin(assetTag).on(asset.id.eq(assetTag.asset.id))
+                .innerJoin(category).on(category.id.eq(assetTag.category.id))
+                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
+                .innerJoin(tag).on(tag.id.eq(assetTag.tag.id))
+                .where(asset.status.eq(true), categoryNameEq(categoryName), subCategoryNameEq(subCategoryName), tagListEq(tagList), containKeyword(keywordList))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(assetSortByIncludedKeywordCount(keywordList).desc(), assetSort(pageable))
+                .fetch();
+
+        Long totalCount = queryFactory.select(asset.id.countDistinct())
+                .from(asset)
+                .innerJoin(assetTag).on(asset.id.eq(assetTag.asset.id))
+                .innerJoin(category).on(category.id.eq(assetTag.category.id))
+                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
+                .innerJoin(tag).on(tag.id.eq(assetTag.tag.id))
+                .where(asset.status.eq(true), categoryNameEq(categoryName), subCategoryNameEq(subCategoryName), tagListEq(tagList), containKeyword(keywordList))
+                .fetchOne();
+
+        return new PageImpl<>(result, pageable, totalCount);
     }
 
     public boolean existsAssetByAssetId(Long assetId) {
@@ -513,24 +210,53 @@ public class AssetQueryRepository {
         return fetchOne != null; // 1개가 있는지 없는지 판단 (없으면 null 이므로 null 체크)
     }
 
-    private BooleanBuilder totalCondition(List<String> splitKeywordList){
-        BooleanBuilder builder = new BooleanBuilder();
+    private BooleanExpression categoryNameEq(String categoryName) {
+        return StringUtils.hasText(categoryName) ? category.categoryName.eq(categoryName) : null;
+    }
 
-        for(String keyword : splitKeywordList){
-            builder.or(assetNameLike(keyword));
-        }
+    private BooleanExpression subCategoryNameEq(String subCategoryName) {
+        return StringUtils.hasText(subCategoryName) ? subCategory.subCategoryName.eq(subCategoryName) : null;
+    }
 
-        return builder;
+    private BooleanExpression tagNameEq(String tagName){
+        return StringUtils.hasText(tagName) ? tag.tagName.eq(tagName) : null;
     }
 
     private BooleanExpression assetNameLike(String keyword){
         return StringUtils.hasText(keyword) ? asset.assetName.containsIgnoreCase(keyword) : null;
     }
 
+    private BooleanBuilder tagListEq(List<String> tagList){
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(tagList == null || tagList.isEmpty()){
+            return null;
+        }
+
+        for(String tag : tagList){
+            builder.and(tagNameEq(tag));
+        }
+        return builder;
+    }
+
+    private BooleanBuilder containKeyword(List<String> splitKeywordList){
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(splitKeywordList == null || splitKeywordList.isEmpty()){
+            return null;
+        }
+
+        for(String keyword : splitKeywordList){
+            builder.or(assetNameLike(keyword));
+        }
+        return builder;
+    }
+
     /**
      * 정렬 기준
      */
     private OrderSpecifier<?> assetSort(Pageable pageable) {
+
         if (!pageable.getSort().isEmpty()) {
             for (Sort.Order order : pageable.getSort()) {
                 Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
@@ -562,73 +288,85 @@ public class AssetQueryRepository {
 
         NumberExpression<Integer> expression;
 
-        switch (keywordList.size()) {
-            case 1:
-                expression = new CaseBuilder()
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))).then(1)
-                        .otherwise(0);
-                break;
-            case 2:
-                expression = new CaseBuilder()
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))).then(3)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))).then(2)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(1))).then(1)
-                        .otherwise(0);
-                break;
-            case 3:
-                expression = new CaseBuilder()
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(7)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))).then(6)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(5)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(1))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(4)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))).then(3)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(1))).then(2)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(2))).then(1)
-                        .otherwise(0);
-                break;
-            default:
-                expression = new CaseBuilder()
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(15)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(14)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(13)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(12)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(1))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(11)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))).then(10)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(9)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(8)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(1))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(7)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(1))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(6)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(2))
-                                .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(5)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(0))).then(4)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(1))).then(3)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(2))).then(2)
-                        .when(asset.assetName.containsIgnoreCase(keywordList.get(3))).then(1)
-                        .otherwise(0);
-                break;
+        if(keywordList == null || keywordList.isEmpty()){
+            expression = new CaseBuilder()
+                    .when(asset.assetName.isNotNull()).then(1)
+                    .otherwise(0);
+        } else if (keywordList.size() == 1) {
+            expression = new CaseBuilder()
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))).then(1)
+                    .otherwise(0);
+        } else if (keywordList.size() == 2) {
+            expression = new CaseBuilder()
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))).then(3)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))).then(2)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(1))).then(1)
+                    .otherwise(0);
+        } else if (keywordList.size() == 3) {
+            expression = new CaseBuilder()
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(7)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))).then(6)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(5)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(1))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(4)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))).then(3)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(1))).then(2)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(2))).then(1)
+                    .otherwise(0);
+        } else {
+            expression = new CaseBuilder()
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(15)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(14)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(13)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(12)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(1))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(11)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(1)))).then(10)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(9)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(8)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(1))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(2)))).then(7)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(1))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(6)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(2))
+                            .and(asset.assetName.containsIgnoreCase(keywordList.get(3)))).then(5)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(0))).then(4)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(1))).then(3)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(2))).then(2)
+                    .when(asset.assetName.containsIgnoreCase(keywordList.get(3))).then(1)
+                    .otherwise(0);
         }
         return expression;
+    }
+
+    public static class OrderByNull extends OrderSpecifier {
+
+        private static final OrderByNull DEFAULT = new OrderByNull();
+
+        private OrderByNull() {
+            super(Order.ASC, NullExpression.DEFAULT, NullHandling.Default);
+        }
+
+        public static OrderByNull getDefault() {
+            return OrderByNull.DEFAULT;
+        }
     }
 }

--- a/src/main/java/com/phoenix/assetbe/service/AssetService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AssetService.java
@@ -87,6 +87,20 @@ public class AssetService {
         return new AssetResponse.AssetListOutDTO(assetList);
     }
 
+    public AssetResponse.AssetsOutDTO getAssetListBySearchService(List<String> keywords,
+                                                                  Pageable pageable, MyUserDetails myUserDetails) {
+        Page<AssetResponse.AssetsOutDTO.AssetDetail> assetDetailList;
+        if(myUserDetails != null) {
+            Long userId = myUserDetails.getUser().getId();
+            assetDetailList = assetQueryRepository
+                    .findAssetListWithUserIdAndPaginationBySearch(userId, keywords, pageable);
+        }else {
+            assetDetailList = assetQueryRepository
+                    .findAssetListWithPaginationBySearch(keywords, pageable);
+        }
+        return new AssetResponse.AssetsOutDTO(assetDetailList);
+    }
+
     public Asset findAssetById(Long assetId){
         Asset assetPS = assetRepository.findById(assetId).orElseThrow(
                 () -> new Exception400("id", "존재하지 않는 에셋입니다. "));

--- a/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
@@ -167,7 +167,9 @@ public class AssetControllerTest extends MyRestDoc {
 
         // When
         ResultActions resultActions = mockMvc.perform(
-                get("/assets/{categoryName}", categoryName).param("page", page).param("size", size));
+                get("/assets/{categoryName}", categoryName)
+                        .param("page", page)
+                        .param("size", size));
 
         // Then
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
@@ -184,16 +186,19 @@ public class AssetControllerTest extends MyRestDoc {
 
     @DisplayName("카테고리별 에셋 조회 로그인유저 성공")
     @WithUserDetails(value = "yangjinho3@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+
     @Test
     public void get_asset_list_with_user_id_and_pagination_by_category_test() throws Exception {
         // Given
-        String categoryName = "luxury";
-        String page = "1";
+        String categoryName = "pretty";
+        String page = "0";
         String size = "4";
 
         // When
         ResultActions resultActions = mockMvc.perform(
-                get("/assets/{categoryName}", categoryName).param("page", page).param("size", size));
+                get("/assets/{categoryName}", categoryName)
+                        .param("page", page)
+                        .param("size", size));
 
         // Then
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
@@ -202,9 +207,64 @@ public class AssetControllerTest extends MyRestDoc {
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("성공"))
                 .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.data.assetList[1].assetId").value(19L))
-                .andExpect(jsonPath("$.data.assetList[1].wishlistId").doesNotExist())
-                .andExpect(jsonPath("$.data.assetList[1].cartId").doesNotExist());
+                .andExpect(jsonPath("$.data.assetList[0].assetId").value(12L))
+                .andExpect(jsonPath("$.data.assetList[0].wishlistId").value(3L))
+                .andExpect(jsonPath("$.data.assetList[0].cartId").value(8L));
+    }
+
+    @DisplayName("카테고리별 에셋 검색 비로그인유저 성공")
+    @Test
+    public void get_asset_list_with_pagination_and_search_by_category_test() throws Exception {
+        // Given
+        String categoryName = "luxury";
+        String page = "0";
+        String size = "4";
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets/{categoryName}", categoryName)
+                        .param("page", page)
+                        .param("size", size)
+                        .param("keyword", "man", "boy"));
+
+        // Then
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 response : " + responseBody);
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetList.size()").value(3L))
+                .andExpect(jsonPath("$.data.assetList[0].wishlistId").doesNotExist())
+                .andExpect(jsonPath("$.data.assetList[0].cartId").doesNotExist());
+    }
+
+    @DisplayName("카테고리별 에셋 검색 로그인유저 성공")
+    @WithUserDetails(value = "유현주@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void get_asset_list_with_user_id_and_pagination_and_search_by_category_test() throws Exception {
+        // Given
+        String categoryName = "pretty";
+        String page = "0";
+        String size = "4";
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets/{categoryName}", categoryName)
+                        .param("page", page)
+                        .param("size", size)
+                        .param("keyword", "man", "boy"));
+
+        // Then
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 response : " + responseBody);
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetList[0].assetId").value(12L))
+                .andExpect(jsonPath("$.data.assetList[0].wishlistId").value(3L))
+                .andExpect(jsonPath("$.data.assetList[0].cartId").value(8L));
     }
 
     @DisplayName("하위 카테고리별 에셋 조회 비로그인 성공")
@@ -291,7 +351,7 @@ public class AssetControllerTest extends MyRestDoc {
         // when
         ResultActions resultActions = mockMvc.perform(
                 get("/assets/search")
-                        .param("keyword", "luxury", "man", "cute")
+                        .param("keyword", "man")
                         .param("page", page)
                         .param("size", size));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();

--- a/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
@@ -257,4 +257,49 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data.totalElement").value(1L));
     }
+
+    @DisplayName("에셋 검색 로그인 성공")
+    @WithUserDetails(value = "user1@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void find_asset_list_with_user_id_and_pagination_by_search_test() throws Exception {
+        // given
+        String page = "0";
+        String size = "4";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .get("/assets/search")
+                .param("keyword", "a", "c", "d", "f", "g")
+                .param("page", page)
+                .param("size", size));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200));
+    }
+
+    @DisplayName("에셋 검색 비로그인 성공")
+    @Test
+    public void find_asset_list_with_pagination_by_search_test() throws Exception {
+        // given
+        String page = "0";
+        String size = "4";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                .get("/assets/search")
+                .param("keyword", "a", "c", "d", "f", "g")
+                .param("page", page)
+                .param("size", size));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200));
+    }
 }

--- a/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
@@ -258,20 +258,19 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.data.totalElement").value(1L));
     }
 
-    @DisplayName("에셋 검색 로그인 성공")
-    @WithUserDetails(value = "user1@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("에셋 검색 비로그인 성공")
     @Test
-    public void find_asset_list_with_user_id_and_pagination_by_search_test() throws Exception {
+    public void find_asset_list_with_pagination_by_search_test() throws Exception {
         // given
         String page = "0";
         String size = "4";
 
         // when
-        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets/search")
-                .param("keyword", "a", "c", "d", "f", "g")
-                .param("page", page)
-                .param("size", size));
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets/search")
+                        .param("keyword", "luxury man", "sexy woman", "sexy man")
+                        .param("page", page)
+                        .param("size", size));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
         System.out.println("테스트 : " + responseBody);
 
@@ -281,19 +280,20 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.status").value(200));
     }
 
-    @DisplayName("에셋 검색 비로그인 성공")
+    @DisplayName("에셋 검색 로그인 성공")
+    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
-    public void find_asset_list_with_pagination_by_search_test() throws Exception {
+    public void find_asset_list_with_user_id_and_pagination_by_search_test() throws Exception {
         // given
         String page = "0";
-        String size = "4";
+        String size = "22";
 
         // when
-        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
-                .get("/assets/search")
-                .param("keyword", "a", "c", "d", "f", "g")
-                .param("page", page)
-                .param("size", size));
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets/search")
+                        .param("keyword", "luxury", "man", "cute")
+                        .param("page", page)
+                        .param("size", size));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
         System.out.println("테스트 : " + responseBody);
 

--- a/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AssetControllerTest.java
@@ -60,7 +60,7 @@ public class AssetControllerTest extends MyRestDoc {
         myTestSetUp.saveCategoryAndSubCategoryAndTag(assetList);
     }
 
-    @DisplayName("에셋 상세정보 비로그인유저 성공")
+    @DisplayName("에셋 상세정보: 비로그인유저 - 성공")
     @Test
     public void get_asset_details_test() throws Exception {
         // Given
@@ -84,7 +84,7 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.data.assetId").value(3L));
     }
 
-    @DisplayName("에셋 상세정보 로그인유저 성공")
+    @DisplayName("에셋 상세정보: 로그인유저 - 성공")
     @WithUserDetails(value = "yuhyunju1@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
     public void get_asset_details_with_user_test() throws Exception {
@@ -110,7 +110,7 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.data.wishlistId").value(1L));
     }
 
-    @DisplayName("개별에셋 비로그인유저 성공")
+    @DisplayName("개별 에셋: 비로그인유저 - 성공")
     @Test
     public void get_asset_list_test() throws Exception {
         // Given
@@ -133,7 +133,7 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.data.assetList[0].cartId").doesNotExist());
     }
 
-    @DisplayName("개별에셋 로그인유저 성공")
+    @DisplayName("개별 에셋: 로그인유저 - 성공")
     @WithUserDetails(value = "yangjinho3@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
     public void get_asset_list_with_user_test() throws Exception {
@@ -157,9 +157,9 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.data.assetList[0].cartId").value(18L));
     }
 
-    @DisplayName("카테고리별 에셋 조회 비로그인유저 성공")
+    @DisplayName("카테고리별 에셋 조회: 비로그인유저 - 성공")
     @Test
-    public void get_asset_list_with_pagination_by_category_test() throws Exception {
+    public void get_asset_list_by_category_test() throws Exception {
         // Given
         String categoryName = "luxury";
         String page = "0";
@@ -184,11 +184,10 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.data.assetList[0].cartId").doesNotExist());
     }
 
-    @DisplayName("카테고리별 에셋 조회 로그인유저 성공")
+    @DisplayName("카테고리별 에셋 조회: 로그인유저 - 성공")
     @WithUserDetails(value = "yangjinho3@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-
     @Test
-    public void get_asset_list_with_user_id_and_pagination_by_category_test() throws Exception {
+    public void get_asset_list_with_user_by_category_test() throws Exception {
         // Given
         String categoryName = "pretty";
         String page = "0";
@@ -208,13 +207,13 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.msg").value("성공"))
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data.assetList[0].assetId").value(12L))
-                .andExpect(jsonPath("$.data.assetList[0].wishlistId").value(3L))
-                .andExpect(jsonPath("$.data.assetList[0].cartId").value(8L));
+                .andExpect(jsonPath("$.data.assetList[0].wishlistId").doesNotExist())
+                .andExpect(jsonPath("$.data.assetList[0].cartId").value(24L));
     }
 
-    @DisplayName("카테고리별 에셋 검색 비로그인유저 성공")
+    @DisplayName("카테고리별 에셋 검색: 비로그인유저 - 성공")
     @Test
-    public void get_asset_list_with_pagination_and_search_by_category_test() throws Exception {
+    public void get_asset_list_by_category_with_search_test() throws Exception {
         // Given
         String categoryName = "luxury";
         String page = "0";
@@ -239,10 +238,10 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.data.assetList[0].cartId").doesNotExist());
     }
 
-    @DisplayName("카테고리별 에셋 검색 로그인유저 성공")
-    @WithUserDetails(value = "유현주@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("카테고리별 에셋 검색: 로그인유저 - 성공")
+    @WithUserDetails(value = "yuhyunju1@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
-    public void get_asset_list_with_user_id_and_pagination_and_search_by_category_test() throws Exception {
+    public void get_asset_list_with_user_by_category_with_search_test() throws Exception {
         // Given
         String categoryName = "pretty";
         String page = "0";
@@ -262,14 +261,14 @@ public class AssetControllerTest extends MyRestDoc {
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("성공"))
                 .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.data.assetList[0].assetId").value(12L))
-                .andExpect(jsonPath("$.data.assetList[0].wishlistId").value(3L))
-                .andExpect(jsonPath("$.data.assetList[0].cartId").value(8L));
+                .andExpect(jsonPath("$.data.assetList[0].assetId").value(8L))
+                .andExpect(jsonPath("$.data.assetList[0].wishlistId").doesNotExist())
+                .andExpect(jsonPath("$.data.assetList[0].cartId").value(4L));
     }
 
-    @DisplayName("하위 카테고리별 에셋 조회 비로그인 성공")
+    @DisplayName("하위 카테고리별 에셋 조회: 비로그인유저 성공")
     @Test
-    public void find_asset_list_with_pagination_by_sub_category_test() throws Exception {
+    public void find_asset_list_by_sub_category_test() throws Exception {
         // Given
         String categoryName = "luxury";
         String subCategoryName = "man";
@@ -292,10 +291,10 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.data.totalElement").value(1L));
     }
 
-    @DisplayName("하위 카테고리별 에셋 조회 로그인 성공")
+    @DisplayName("하위 카테고리별 에셋 조회: 로그인유저 - 성공")
     @WithUserDetails(value = "yangjinho3@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
-    public void find_asset_list_with_user_id_and_pagination_by_sub_category_test() throws Exception {
+    public void find_asset_list_with_user_by_sub_category_test() throws Exception {
         // Given
         String categoryName = "luxury";
         String subCategoryName = "man";
@@ -318,9 +317,9 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.data.totalElement").value(1L));
     }
 
-    @DisplayName("에셋 검색 비로그인 성공")
+    @DisplayName("에셋 검색: 비로그인유저 - 성공")
     @Test
-    public void find_asset_list_with_pagination_by_search_test() throws Exception {
+    public void find_asset_list_by_search_test() throws Exception {
         // given
         String page = "0";
         String size = "4";
@@ -340,10 +339,10 @@ public class AssetControllerTest extends MyRestDoc {
                 .andExpect(jsonPath("$.status").value(200));
     }
 
-    @DisplayName("에셋 검색 로그인 성공")
-    @WithUserDetails(value = "양진호@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("에셋 검색: 로그인유저 - 성공")
+    @WithUserDetails(value = "yangjinho3@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
-    public void find_asset_list_with_user_id_and_pagination_by_search_test() throws Exception {
+    public void find_asset_list_with_user_by_search_test() throws Exception {
         // given
         String page = "0";
         String size = "22";
@@ -361,5 +360,61 @@ public class AssetControllerTest extends MyRestDoc {
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("성공"))
                 .andExpect(jsonPath("$.status").value(200));
+    }
+
+    @DisplayName("카테고리별 에셋 조회: 태그, 비로그인유저 - 성공")
+    @Test
+    public void get_asset_list_by_category_with_tag_test() throws Exception {
+        // Given
+        String categoryName = "luxury";
+        String page = "0";
+        String size = "28";
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets/{categoryName}", categoryName)
+                        .param("page", page)
+                        .param("size", size)
+                        .param("tag", "tag1"));
+
+        // Then
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 response : " + responseBody);
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetList.size()").value(6L))
+                .andExpect(jsonPath("$.data.assetList[0].wishlistId").doesNotExist())
+                .andExpect(jsonPath("$.data.assetList[0].cartId").doesNotExist());
+    }
+
+    @DisplayName("카테고리별 에셋 조회: 태그, 로그인유저 - 성공")
+    @WithUserDetails(value = "yuhyunju1@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void get_asset_list_with_user_by_category_with_tag_test() throws Exception {
+        // Given
+        String categoryName = "pretty";
+        String page = "0";
+        String size = "28";
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                get("/assets/{categoryName}", categoryName)
+                        .param("page", page)
+                        .param("size", size)
+                        .param("tag", "tag1"));
+
+        // Then
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 response : " + responseBody);
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("성공"))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.assetList.size()").value(6L))
+                .andExpect(jsonPath("$.data.assetList[0].assetId").value(12L))
+                .andExpect(jsonPath("$.data.assetList[0].wishlistId").value(3L))
+                .andExpect(jsonPath("$.data.assetList[0].cartId").value(8L));
     }
 }

--- a/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
+++ b/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
@@ -57,7 +57,7 @@ public class AssetQueryRepositoryTest {
         Pageable pageable = PageRequest.of(page, size, Sort.by("releaseDate").descending());
 
         // When
-        Page<AssetResponse.AssetListOutDTO.AssetOutDTO> result = assetQueryRepository.findAssetListWithUserIdAndPaging(userId, pageable);
+        Page<AssetResponse.AssetListOutDTO.AssetOutDTO> result = assetQueryRepository.findAssetListWithUserAndPage(userId, pageable);
 
         // Then
         assertThat(result.getContent().size(), is(3));

--- a/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
+++ b/src/test/java/com/phoenix/assetbe/model/asset/AssetQueryRepositoryTest.java
@@ -57,7 +57,7 @@ public class AssetQueryRepositoryTest {
         Pageable pageable = PageRequest.of(page, size, Sort.by("releaseDate").descending());
 
         // When
-        Page<AssetResponse.AssetListOutDTO.AssetOutDTO> result = assetQueryRepository.findAssetListWithUserAndPage(userId, pageable);
+        Page<AssetResponse.AssetListOutDTO.AssetOutDTO> result = assetQueryRepository.findAssetListWithUser(userId, null, pageable);
 
         // Then
         assertThat(result.getContent().size(), is(3));


### PR DESCRIPTION
## Motivation

- 에셋 검색 기능 구현
- 카테고리별, 서브카테고리별 에셋 조회 + 태그, 키워드 조건 검색
- 로그인 유저, 비로그인 유저 구분
- 페이지네이션
- 태그, 키워드, 페이지번호, 페이지사이즈를 쿼리스트링으로 받는다.
- 태그, 키워드, 페이지번호, 페이지사이즈를 동적으로 구현

resolved #17 
