### PR TITLE
test : #136 관리자 에셋 활성화 테스트 완료

### DIFF
--- a/src/main/java/com/phoenix/assetbe/controller/UserController.java
+++ b/src/main/java/com/phoenix/assetbe/controller/UserController.java
@@ -106,9 +106,9 @@ public class UserController {
         return ResponseEntity.ok().body(responseDTO);
     }
 
-    @GetMapping("/s/user/{id}")
-    public ResponseEntity<?> getMyInfo(@PathVariable Long id, @AuthenticationPrincipal MyUserDetails myUserDetails) {
-        UserResponse.GetMyInfoOutDTO getMyInfoOutDTO = userService.getMyInfoService(id, myUserDetails);
+    @GetMapping("/s/user")
+    public ResponseEntity<?> getMyInfo(@AuthenticationPrincipal MyUserDetails myUserDetails) {
+        UserResponse.GetMyInfoOutDTO getMyInfoOutDTO = userService.getMyInfoService(myUserDetails);
         ResponseDTO<?> responseDTO = new ResponseDTO<>(getMyInfoOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }

--- a/src/main/java/com/phoenix/assetbe/core/config/MySecurityConfig.java
+++ b/src/main/java/com/phoenix/assetbe/core/config/MySecurityConfig.java
@@ -75,7 +75,7 @@ public class MySecurityConfig {
         // 8. 인증 실패 처리
         http.exceptionHandling().authenticationEntryPoint((request, response, authException) -> {
             log.warn("인증되지 않은 사용자가 자원에 접근하려 합니다 : "+authException.getMessage());
-            MyFilterResponseUtil.unAuthorized(response, new Exception401("인증되지 않았습니다"));
+            MyFilterResponseUtil.unAuthorized(response, new Exception401("인증되지 않았습니다. "));
         });
 
         // 10. 권한 실패 처리

--- a/src/main/java/com/phoenix/assetbe/core/dummy/DummyEntity.java
+++ b/src/main/java/com/phoenix/assetbe/core/dummy/DummyEntity.java
@@ -78,4 +78,25 @@ public class DummyEntity {
                 .thumbnailUrl(assetName + ".thumbnailUrl")
                 .build();
     }
+
+    public Asset newInactiveAsset(String assetName, Double price, Double size, LocalDate date, Double rating) {
+        return Asset.builder()
+                .assetName(assetName)
+                .price(price)
+                .description("assetName은 price원입니다. ")
+                .discount(0)
+                .size(size)
+                .extension(".FBX")
+                .releaseDate(date)
+                .creator("NationA")
+                .rating(rating)
+                .wishCount(1111L)
+                .visitCount(2222L)
+                .reviewCount(0L)
+                .status(false)
+                .updatedAt(LocalDateTime.now())
+                .fileUrl(assetName + ".fileUrl")
+                .thumbnailUrl(assetName + ".thumbnailUrl")
+                .build();
+    }
 }

--- a/src/main/java/com/phoenix/assetbe/core/dummy/DummyEntity.java
+++ b/src/main/java/com/phoenix/assetbe/core/dummy/DummyEntity.java
@@ -78,25 +78,4 @@ public class DummyEntity {
                 .thumbnailUrl(assetName + ".thumbnailUrl")
                 .build();
     }
-
-    public Asset newInactiveAsset(String assetName, Double price, Double size, LocalDate date, Double rating) {
-        return Asset.builder()
-                .assetName(assetName)
-                .price(price)
-                .description("assetName은 price원입니다. ")
-                .discount(0)
-                .size(size)
-                .extension(".FBX")
-                .releaseDate(date)
-                .creator("NationA")
-                .rating(rating)
-                .wishCount(1111L)
-                .visitCount(2222L)
-                .reviewCount(0L)
-                .status(false)
-                .updatedAt(LocalDateTime.now())
-                .fileUrl(assetName + ".fileUrl")
-                .thumbnailUrl(assetName + ".thumbnailUrl")
-                .build();
-    }
 }

--- a/src/main/java/com/phoenix/assetbe/service/AdminService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AdminService.java
@@ -51,4 +51,16 @@ public class AdminService {
             asset.changeStatusToINACTIVE();
         }
     }
+
+    @Transactional
+    public void activeAssetService(AdminRequest.ActiveAssetInDTO activeAssetInDTO) {
+        List<Asset> assetList = assetQueryRepository.getAssetListByAssetIdList(activeAssetInDTO.getAssets());
+
+        for (Asset asset: assetList) {
+            if (asset.isStatus()) {
+                throw new Exception400("status error", asset.getId() + "번 에셋은 이미 활성화되어 있습니다. ");
+            }
+            asset.changeStatusToACTIVE();
+        }
+    }
 }

--- a/src/main/java/com/phoenix/assetbe/service/UserService.java
+++ b/src/main/java/com/phoenix/assetbe/service/UserService.java
@@ -188,9 +188,8 @@ public class UserService {
         }
     }
 
-    public UserResponse.GetMyInfoOutDTO getMyInfoService(Long userId, MyUserDetails myUserDetails) {
-        authCheck(myUserDetails, userId);
-        User userPS = findUserById(userId);
+    public UserResponse.GetMyInfoOutDTO getMyInfoService(MyUserDetails myUserDetails) {
+        User userPS = findUserById(myUserDetails.getUser().getId());
         return new UserResponse.GetMyInfoOutDTO(userPS);
     }
 

--- a/src/test/java/com/phoenix/assetbe/controller/AdminControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AdminControllerTest.java
@@ -162,7 +162,7 @@ public class AdminControllerTest extends MyRestDoc {
     @DisplayName("관리자 에셋 비활성화 실패 : 권한 체크 실패")
     @WithUserDetails(value = "songjaegeun2@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
-    public void inactive_asset_fail1_test() throws Exception {
+    public void inactive_asset_fail_test() throws Exception {
         // given
         List<Long> assetIdList = new ArrayList<>();
         assetIdList.add(1L);
@@ -174,6 +174,58 @@ public class AdminControllerTest extends MyRestDoc {
 
         // when
         ResultActions resultActions = mockMvc.perform(post("/s/admin/asset/inactive")
+                .content(objectMapper.writeValueAsString(inactiveAssetInDTO))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions.andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.msg").value("forbidden"))
+                .andExpect(jsonPath("$.data").value("권한이 없습니다. "));
+        //resultActions.andDo(MockMvcResultHandlers.print()).andDo(document);
+    }
+
+//    @DisplayName("관리자 에셋 활성화 성공")
+//    @WithUserDetails(value = "kuanliza8@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+//    @Test
+//    public void active_asset_test() throws Exception {
+//        // given
+//
+//
+//        List<Long> assetIdList = new ArrayList<>();
+//        assetIdList.add(10L);
+//        assetIdList.add(11L);
+//        assetIdList.add(12L);
+//
+//        AdminRequest.ActiveAssetInDTO activeAssetInDTO = new AdminRequest.ActiveAssetInDTO();
+//        activeAssetInDTO.setAssets(assetIdList);
+//
+//        // when
+//        ResultActions resultActions = mockMvc.perform(post("/s/admin/asset/active")
+//                .content(objectMapper.writeValueAsString(activeAssetInDTO))
+//                .contentType(MediaType.APPLICATION_JSON));
+//
+//        // then
+//        resultActions.andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status").value(200))
+//                .andExpect(jsonPath("$.msg").value("성공"));
+//        //resultActions.andDo(MockMvcResultHandlers.print()).andDo(document);
+//    }
+
+    @DisplayName("관리자 에셋 활성화 실패 : 권한 체크 실패")
+    @WithUserDetails(value = "songjaegeun2@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void active_asset_fail_test() throws Exception {
+        // given
+        List<Long> assetIdList = new ArrayList<>();
+        assetIdList.add(1L);
+        assetIdList.add(2L);
+        assetIdList.add(4L);
+
+        AdminRequest.InactiveAssetInDTO inactiveAssetInDTO = new AdminRequest.InactiveAssetInDTO();
+        inactiveAssetInDTO.setAssets(assetIdList);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/s/admin/asset/active")
                 .content(objectMapper.writeValueAsString(inactiveAssetInDTO))
                 .contentType(MediaType.APPLICATION_JSON));
 

--- a/src/test/java/com/phoenix/assetbe/controller/AdminControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AdminControllerTest.java
@@ -61,8 +61,8 @@ public class AdminControllerTest extends MyRestDoc {
         myTestSetUp.saveUserScenario(userList, assetList);
         myTestSetUp.saveCategoryAndSubCategoryAndTag(assetList);
 
-        Asset inactiveAsset1 = dummy.newInactiveAsset("inactiveAsset1", 10000.0, 10.0, null, 2.5); // 31
-        assetRepository.save(inactiveAsset1);
+        Asset asset1 = Asset.builder().assetName("asset1").status(false).build(); // 31
+        assetRepository.save(asset1);
     }
 
     /**

--- a/src/test/java/com/phoenix/assetbe/controller/AdminControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AdminControllerTest.java
@@ -6,6 +6,7 @@ import com.phoenix.assetbe.core.config.MyTestSetUp;
 import com.phoenix.assetbe.core.dummy.DummyEntity;
 import com.phoenix.assetbe.dto.admin.AdminRequest;
 import com.phoenix.assetbe.model.asset.Asset;
+import com.phoenix.assetbe.model.asset.AssetRepository;
 import com.phoenix.assetbe.model.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,6 +50,8 @@ public class AdminControllerTest extends MyRestDoc {
     private MockMvc mockMvc;
     @Autowired
     private ObjectMapper objectMapper;
+    @Autowired
+    private AssetRepository assetRepository;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -184,32 +187,33 @@ public class AdminControllerTest extends MyRestDoc {
         //resultActions.andDo(MockMvcResultHandlers.print()).andDo(document);
     }
 
-//    @DisplayName("관리자 에셋 활성화 성공")
-//    @WithUserDetails(value = "kuanliza8@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-//    @Test
-//    public void active_asset_test() throws Exception {
-//        // given
-//
-//
-//        List<Long> assetIdList = new ArrayList<>();
-//        assetIdList.add(10L);
-//        assetIdList.add(11L);
-//        assetIdList.add(12L);
-//
-//        AdminRequest.ActiveAssetInDTO activeAssetInDTO = new AdminRequest.ActiveAssetInDTO();
-//        activeAssetInDTO.setAssets(assetIdList);
-//
-//        // when
-//        ResultActions resultActions = mockMvc.perform(post("/s/admin/asset/active")
-//                .content(objectMapper.writeValueAsString(activeAssetInDTO))
-//                .contentType(MediaType.APPLICATION_JSON));
-//
-//        // then
-//        resultActions.andExpect(status().isOk())
-//                .andExpect(jsonPath("$.status").value(200))
-//                .andExpect(jsonPath("$.msg").value("성공"));
-//        //resultActions.andDo(MockMvcResultHandlers.print()).andDo(document);
-//    }
+    @DisplayName("관리자 에셋 활성화 성공")
+    @WithUserDetails(value = "kuanliza8@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    public void active_asset_test() throws Exception {
+        // given
+        List<Asset> assetList = new ArrayList<Asset>();
+        Asset inactiveAsset1 = dummy.newInactiveAsset("inactiveAsset1", 10000.0, 10.0, null, 2.5); // 31
+        assetList.add(inactiveAsset1);
+        assetRepository.saveAll(assetList);
+
+        List<Long> assetIdList = new ArrayList<>();
+        assetIdList.add(31L);
+
+        AdminRequest.ActiveAssetInDTO activeAssetInDTO = new AdminRequest.ActiveAssetInDTO();
+        activeAssetInDTO.setAssets(assetIdList);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/s/admin/asset/active")
+                .content(objectMapper.writeValueAsString(activeAssetInDTO))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.msg").value("성공"));
+        //resultActions.andDo(MockMvcResultHandlers.print()).andDo(document);
+    }
 
     @DisplayName("관리자 에셋 활성화 실패 : 권한 체크 실패")
     @WithUserDetails(value = "songjaegeun2@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)

--- a/src/test/java/com/phoenix/assetbe/controller/AdminControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/AdminControllerTest.java
@@ -60,6 +60,9 @@ public class AdminControllerTest extends MyRestDoc {
 
         myTestSetUp.saveUserScenario(userList, assetList);
         myTestSetUp.saveCategoryAndSubCategoryAndTag(assetList);
+
+        Asset inactiveAsset1 = dummy.newInactiveAsset("inactiveAsset1", 10000.0, 10.0, null, 2.5); // 31
+        assetRepository.save(inactiveAsset1);
     }
 
     /**
@@ -192,11 +195,6 @@ public class AdminControllerTest extends MyRestDoc {
     @Test
     public void active_asset_test() throws Exception {
         // given
-        List<Asset> assetList = new ArrayList<Asset>();
-        Asset inactiveAsset1 = dummy.newInactiveAsset("inactiveAsset1", 10000.0, 10.0, null, 2.5); // 31
-        assetList.add(inactiveAsset1);
-        assetRepository.saveAll(assetList);
-
         List<Long> assetIdList = new ArrayList<>();
         assetIdList.add(31L);
 

--- a/src/test/java/com/phoenix/assetbe/controller/UserControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/UserControllerTest.java
@@ -232,7 +232,7 @@ public class UserControllerTest extends MyRestDoc {
         //resultActions.andDo(MockMvcResultHandlers.print()).andDo(document);
     }
 
-    @DisplayName("내 회원정보 조회 실패 : 권한 체크 실패")
+    @DisplayName("내 회원정보 조회 실패 : 인증 실패")
     @Test
     public void get_my_info_fail_test() throws Exception {
         // given

--- a/src/test/java/com/phoenix/assetbe/controller/UserControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/UserControllerTest.java
@@ -236,7 +236,6 @@ public class UserControllerTest extends MyRestDoc {
     @Test
     public void get_my_info_fail_test() throws Exception {
         // given
-        Long id = 3L;
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/s/user"));

--- a/src/test/java/com/phoenix/assetbe/controller/UserControllerTest.java
+++ b/src/test/java/com/phoenix/assetbe/controller/UserControllerTest.java
@@ -220,7 +220,7 @@ public class UserControllerTest extends MyRestDoc {
         Long id = 2L;
 
         // when
-        ResultActions resultActions = mockMvc.perform(get("/s/user/{id}", id));
+        ResultActions resultActions = mockMvc.perform(get("/s/user"));
 
         // then
         resultActions.andExpect(jsonPath("$.status").value(200));
@@ -233,19 +233,20 @@ public class UserControllerTest extends MyRestDoc {
     }
 
     @DisplayName("내 회원정보 조회 실패 : 권한 체크 실패")
-    @WithUserDetails(value = "songjaegeun2@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
     public void get_my_info_fail_test() throws Exception {
         // given
         Long id = 3L;
 
         // when
-        ResultActions resultActions = mockMvc.perform(get("/s/user/{id}", id));
+        ResultActions resultActions = mockMvc.perform(get("/s/user"));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
 
         // then
-        resultActions.andExpect(jsonPath("$.status").value(403));
-        resultActions.andExpect(jsonPath("$.msg").value("forbidden"));
-        resultActions.andExpect(jsonPath("$.data").value("권한이 없습니다. "));
+        resultActions.andExpect(jsonPath("$.status").value(401));
+        resultActions.andExpect(jsonPath("$.msg").value("unAuthorized"));
+        resultActions.andExpect(jsonPath("$.data").value("인증되지 않았습니다. "));
         //resultActions.andDo(MockMvcResultHandlers.print()).andDo(document);
     }
 

--- a/src/test/java/com/phoenix/assetbe/service/AdminServiceTest.java
+++ b/src/test/java/com/phoenix/assetbe/service/AdminServiceTest.java
@@ -98,4 +98,19 @@ public class AdminServiceTest extends DummyEntity {
         // then
         verify(assetQueryRepository, times(1)).getAssetListByAssetIdList(assetIdList);
     }
+
+    @Test
+    public void testActiveAssetService() throws Exception {
+        // given
+        List<Long> assetIdList = Arrays.asList(1L, 2L, 3L);
+
+        AdminRequest.ActiveAssetInDTO activeAssetInDTO = new AdminRequest.ActiveAssetInDTO();
+        activeAssetInDTO.setAssets(assetIdList);
+
+        // when
+        adminService.activeAssetService(activeAssetInDTO);
+
+        // then
+        verify(assetQueryRepository, times(1)).getAssetListByAssetIdList(assetIdList);
+    }
 }

--- a/src/test/java/com/phoenix/assetbe/service/UserServiceTest.java
+++ b/src/test/java/com/phoenix/assetbe/service/UserServiceTest.java
@@ -151,7 +151,7 @@ public class UserServiceTest extends DummyEntity {
         MyUserDetails myUserDetails = new MyUserDetails(송재근);
 
         // when
-        UserResponse.GetMyInfoOutDTO getMyInfoOutDTO = userService.getMyInfoService(userId, myUserDetails);
+        UserResponse.GetMyInfoOutDTO getMyInfoOutDTO = userService.getMyInfoService(myUserDetails);
 
         // then
         verify(userRepository, times(1)).findById(userId);


### PR DESCRIPTION
## Motivation

- 관리자 에셋 활성화 테스트 완료

```text
close #136 
```

## Proposed Changes

- [x] 기능 구현
- [x] Service Test
- [x] Integration Test

## To reviewers

- PR전, 전체 테스트 성공
- Integration '관리자 에셋 활성화 성공' 테스트시, `MyTestSetUp`의 newAsset `staus`를 `false`로 바꾸고 테스트 해야합니다.
- QueryDSL 사용했습니다.
