### PR TITLE
fix : #14 #99 #106 에셋 조회 오류 & 에셋 등록 오류 해결

### DIFF
--- a/src/main/java/com/phoenix/assetbe/dto/admin/AdminResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/admin/AdminResponse.java
@@ -83,8 +83,9 @@ public class AdminResponse {
                 this.releaseDate = releaseDate;
                 if(updatedAt == null){
                     this.updatedAt = null;
+                }else{
+                    this.updatedAt = LocalDate.from(updatedAt);
                 }
-                this.updatedAt = LocalDate.from(updatedAt);
             }
         }
     }

--- a/src/main/java/com/phoenix/assetbe/dto/admin/AdminResponse.java
+++ b/src/main/java/com/phoenix/assetbe/dto/admin/AdminResponse.java
@@ -81,6 +81,9 @@ public class AdminResponse {
                 this.categoryName = categoryName;
                 this.subCategoryName = subCategoryName;
                 this.releaseDate = releaseDate;
+                if(updatedAt == null){
+                    this.updatedAt = null;
+                }
                 this.updatedAt = LocalDate.from(updatedAt);
             }
         }

--- a/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
+++ b/src/main/java/com/phoenix/assetbe/model/asset/AssetQueryRepository.java
@@ -134,9 +134,9 @@ public class AssetQueryRepository {
                 )
                 .from(asset)
                 .innerJoin(assetTag).on(asset.id.eq(assetTag.asset.id))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
-                .innerJoin(tag).on(tag.id.eq(assetTag.tag.id))
+                .leftJoin(category).on(category.id.eq(assetTag.category.id))
+                .leftJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
+                .leftJoin(tag).on(tag.id.eq(assetTag.tag.id))
                 .leftJoin(wishList).on(wishList.user.id.eq(userId).and(wishList.asset.eq(asset)))
                 .leftJoin(cart).on(cart.user.id.eq(userId).and(cart.asset.eq(asset)))
                 .where(asset.status.eq(true), categoryNameEq(categoryName), subCategoryNameEq(subCategoryName), tagListEq(tagList), containKeyword(keywordList))
@@ -148,9 +148,9 @@ public class AssetQueryRepository {
         Long totalCount = queryFactory.select(asset.id.countDistinct())
                 .from(asset)
                 .innerJoin(assetTag).on(asset.id.eq(assetTag.asset.id))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
-                .innerJoin(tag).on(tag.id.eq(assetTag.tag.id))
+                .leftJoin(category).on(category.id.eq(assetTag.category.id))
+                .leftJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
+                .leftJoin(tag).on(tag.id.eq(assetTag.tag.id))
                 .where(asset.status.eq(true), categoryNameEq(categoryName), subCategoryNameEq(subCategoryName), tagListEq(tagList), containKeyword(keywordList))
                 .fetchOne();
 
@@ -182,9 +182,9 @@ public class AssetQueryRepository {
                 )
                 .from(asset)
                 .innerJoin(assetTag).on(asset.id.eq(assetTag.asset.id))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
-                .innerJoin(tag).on(tag.id.eq(assetTag.tag.id))
+                .leftJoin(category).on(category.id.eq(assetTag.category.id))
+                .leftJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
+                .leftJoin(tag).on(tag.id.eq(assetTag.tag.id))
                 .where(asset.status.eq(true), categoryNameEq(categoryName), subCategoryNameEq(subCategoryName), tagListEq(tagList), containKeyword(keywordList))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -194,9 +194,9 @@ public class AssetQueryRepository {
         Long totalCount = queryFactory.select(asset.id.countDistinct())
                 .from(asset)
                 .innerJoin(assetTag).on(asset.id.eq(assetTag.asset.id))
-                .innerJoin(category).on(category.id.eq(assetTag.category.id))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
-                .innerJoin(tag).on(tag.id.eq(assetTag.tag.id))
+                .leftJoin(category).on(category.id.eq(assetTag.category.id))
+                .leftJoin(subCategory).on(subCategory.id.eq(assetTag.subCategory.id))
+                .leftJoin(tag).on(tag.id.eq(assetTag.tag.id))
                 .where(asset.status.eq(true), categoryNameEq(categoryName), subCategoryNameEq(subCategoryName), tagListEq(tagList), containKeyword(keywordList))
                 .fetchOne();
 
@@ -223,8 +223,8 @@ public class AssetQueryRepository {
                 )
                 .from(asset)
                 .innerJoin(assetSubCategory).on(assetSubCategory.asset.id.eq(asset.id))
-                .innerJoin(category).on(category.id.eq(assetSubCategory.category.id))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetSubCategory.subCategory.id))
+                .leftJoin(category).on(category.id.eq(assetSubCategory.category.id))
+                .leftJoin(subCategory).on(subCategory.id.eq(assetSubCategory.subCategory.id))
                 .where(statusEq(status), assetNumberEq(assetNumber), categoryNameEq(categoryName), subCategoryNameEq(subCategoryName), containAllKeyword(assetNameList))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -234,13 +234,14 @@ public class AssetQueryRepository {
         Long totalCount = queryFactory.select(asset.id.count())
                 .from(asset)
                 .innerJoin(assetSubCategory).on(assetSubCategory.asset.id.eq(asset.id))
-                .innerJoin(category).on(category.id.eq(assetSubCategory.category.id))
-                .innerJoin(subCategory).on(subCategory.id.eq(assetSubCategory.subCategory.id))
+                .leftJoin(category).on(category.id.eq(assetSubCategory.category.id))
+                .leftJoin(subCategory).on(subCategory.id.eq(assetSubCategory.subCategory.id))
                 .where(statusEq(status), assetNumberEq(assetNumber), categoryNameEq(categoryName), subCategoryNameEq(subCategoryName), containAllKeyword(assetNameList))
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, totalCount);
     }
+
     public boolean existsAssetByAssetId(Long assetId) {
         Integer fetchOne = queryFactory
                 .selectOne()

--- a/src/main/java/com/phoenix/assetbe/service/AdminService.java
+++ b/src/main/java/com/phoenix/assetbe/service/AdminService.java
@@ -367,22 +367,48 @@ public class AdminService {
 
     private void addTagList(Asset assetPS, Category categoryPS, SubCategory subCategoryPS, AdminRequest.AddAssetInDTO addAssetInDTO){
         List<String> addTagList = addAssetInDTO.getAddTagList();
-        List<String> tagNameListPS = tagRepository.findTagNameList();
-        List<Tag> tagList = new ArrayList<>(); // 새로 태그 테이블에 등록할 태그리스트
-        for (String tagName: addTagList) {
-            if (!tagNameListPS.contains(tagName)) {
-                Tag tag = Tag.builder().tagName(tagName).build();
-                tagList.add(tag);
+        if(addTagList == null){
+            AssetTag assetTag = AssetTag.builder().asset(assetPS).category(categoryPS).subCategory(subCategoryPS).tag(null).build();
+            try {
+                assetTagRepository.save(assetTag);
+            }catch (Exception e){
+                throw new Exception500("에셋태그 저장이 실패했습니다. ");
+            }
+        }else {
+            List<Tag> tagListPS = tagRepository.findAll();
+            List<String> tagNameList = new ArrayList<>();
+            for (Tag tag : tagListPS) {
+                tagNameList.add(tag.getTagName());
+            }
+            List<Tag> tagList = new ArrayList<>(); // 새로 태그 테이블에 등록할 태그리스트
+            for (String tagName : addTagList) {
+                if (!tagNameList.contains(tagName)) {
+                    Tag tag = Tag.builder().tagName(tagName).build();
+                    tagList.add(tag);
+                }
+            }
+            try {
+                tagRepository.saveAll(tagList);
+            }catch (Exception e) {
+                throw new Exception500("새로운 태그 생성이 실패했습니다. ");
+            }
+            for (Tag tag : tagListPS) {
+                for (String tagName : addTagList) {
+                    if (tag.getTagName().equals(tagName)) {
+                        tagList.add(tag);
+                    }
+                }
+            }
+            List<AssetTag> assetTagList = new ArrayList<>();
+            for (Tag tag : tagList) {
+                AssetTag assetTag = AssetTag.builder().asset(assetPS).category(categoryPS).subCategory(subCategoryPS).tag(tag).build();
+                assetTagList.add(assetTag);
+            }
+            try {
+                assetTagRepository.saveAll(assetTagList);
+            }catch (Exception e){
+                throw new Exception500("에셋태그 저장이 실패했습니다. ");
             }
         }
-        tagRepository.saveAll(tagList);
-
-        List<AssetTag> assetTagList = new ArrayList<>();
-        for(Tag tag : tagList) {
-            AssetTag assetTag = AssetTag.builder().asset(assetPS).category(categoryPS).subCategory(subCategoryPS).tag(tag).build();
-            assetTagList.add(assetTag);
-        }
-        assetTagRepository.saveAll(assetTagList);
     }
-
 }

--- a/src/main/resources/static/docs/api-docs.html
+++ b/src/main/resources/static/docs/api-docs.html
@@ -1256,6 +1256,15 @@ Content-Length: 1867
       "releaseDate" : "2023-06-24",
       "updatedAt" : "2023-06-28"
     }, {
+      "assetNumber" : "20230621-000021",
+      "assetName" : "luxury boy",
+      "status" : "active",
+      "price" : 1000.0,
+      "categoryName" : "luxury",
+      "subCategoryName" : "boy",
+      "releaseDate" : "2023-06-21",
+      "updatedAt" : "2023-06-28"
+    }, {
       "assetNumber" : "20230622-000022",
       "assetName" : "luxury girl",
       "status" : "active",
@@ -1274,24 +1283,6 @@ Content-Length: 1867
       "releaseDate" : "2023-06-23",
       "updatedAt" : "2023-06-28"
     }, {
-      "assetNumber" : "20230620-000020",
-      "assetName" : "luxury woman",
-      "status" : "active",
-      "price" : 5000.0,
-      "categoryName" : "luxury",
-      "subCategoryName" : "woman",
-      "releaseDate" : "2023-06-20",
-      "updatedAt" : "2023-06-28"
-    }, {
-      "assetNumber" : "20230621-000021",
-      "assetName" : "luxury boy",
-      "status" : "active",
-      "price" : 1000.0,
-      "categoryName" : "luxury",
-      "subCategoryName" : "boy",
-      "releaseDate" : "2023-06-21",
-      "updatedAt" : "2023-06-28"
-    }, {
       "assetNumber" : "20230619-000019",
       "assetName" : "luxury man",
       "status" : "active",
@@ -1299,6 +1290,15 @@ Content-Length: 1867
       "categoryName" : "luxury",
       "subCategoryName" : "man",
       "releaseDate" : "2023-06-19",
+      "updatedAt" : "2023-06-28"
+    }, {
+      "assetNumber" : "20230620-000020",
+      "assetName" : "luxury woman",
+      "status" : "active",
+      "price" : 5000.0,
+      "categoryName" : "luxury",
+      "subCategoryName" : "woman",
+      "releaseDate" : "2023-06-20",
       "updatedAt" : "2023-06-28"
     } ],
     "size" : 100,
@@ -2006,15 +2006,6 @@ Content-Length: 1292
   "msg" : "성공",
   "data" : {
     "orderList" : [ {
-      "orderNumber" : "20230628-000004",
-      "orderDate" : "2023-06-28",
-      "assetName" : "agggg 외 11건",
-      "assetCount" : 12,
-      "email" : "leeroun5@nate.com",
-      "price" : 21000.0,
-      "paymentTool" : "국민카드",
-      "status" : true
-    }, {
       "orderNumber" : "20230628-000002",
       "orderDate" : "2023-06-28",
       "assetName" : "abbbb 외 9건",
@@ -2029,6 +2020,15 @@ Content-Length: 1292
       "assetName" : "adddd 외 10건",
       "assetCount" : 11,
       "email" : "leejihun4@nate.com",
+      "price" : 21000.0,
+      "paymentTool" : "국민카드",
+      "status" : true
+    }, {
+      "orderNumber" : "20230628-000004",
+      "orderDate" : "2023-06-28",
+      "assetName" : "agggg 외 11건",
+      "assetCount" : 12,
+      "email" : "leeroun5@nate.com",
       "price" : 21000.0,
       "paymentTool" : "국민카드",
       "status" : true
@@ -3524,7 +3524,7 @@ X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-Content-Length: 731
+Content-Length: 746
 
 {
   "status" : 200,
@@ -3545,7 +3545,7 @@ Content-Length: 731
     "wishCount" : null,
     "visitCount" : 2223,
     "wishlistId" : null,
-    "previewList" : [ "preview.url", "asset3_1_previewUrl", "asset3_2_previewUrl", "asset3_3_previewUrl" ],
+    "previewList" : [ "preview.url", "preview.url", "asset3_1_previewUrl", "asset3_2_previewUrl", "asset3_3_previewUrl" ],
     "tagList" : [ "tag1", "tag10", "tag2", "tag3", "tag4", "tag5", "tag6", "tag7", "tag8", "tag9" ]
   }
 }</code></pre>
@@ -3605,7 +3605,7 @@ X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-Content-Length: 735
+Content-Length: 747
 
 {
   "status" : 200,
@@ -3621,12 +3621,12 @@ Content-Length: 735
     "fileSize" : 5.0,
     "fileUrl" : "fbx/2023/06/27/50183637-2dff-4e5e-8b1b-07153ac11b64.fbx",
     "creator" : "NationA",
-    "rating" : 1.0,
-    "reviewCount" : 1,
-    "wishCount" : null,
+    "rating" : 0.0,
+    "reviewCount" : 0,
+    "wishCount" : 4,
     "visitCount" : 2223,
     "wishlistId" : 1,
-    "previewList" : [ "preview.url", "asset10_1_previewUrl", "asset10_2_previewUrl", "asset10_3_previewUrl" ],
+    "previewList" : [ "preview.url", "preview.url", "asset10_1_previewUrl", "asset10_2_previewUrl", "asset10_3_previewUrl" ],
     "tagList" : [ "tag1", "tag10", "tag2", "tag3", "tag4", "tag5", "tag6", "tag7", "tag8", "tag9" ]
   }
 }</code></pre>
@@ -3704,7 +3704,7 @@ X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-Content-Length: 1385
+Content-Length: 1382
 
 {
   "status" : 200,
@@ -3718,21 +3718,8 @@ Content-Length: 1385
       "discountPrice" : 5000.0,
       "releaseDate" : "2023-06-30",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 1.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
-      "wishlistId" : null,
-      "cartId" : null
-    }, {
-      "assetId" : 29,
-      "assetName" : "dirty runner",
-      "price" : 4000.0,
-      "discount" : 0,
-      "discountPrice" : 4000.0,
-      "releaseDate" : "2023-06-29",
-      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -3744,8 +3731,21 @@ Content-Length: 1385
       "discountPrice" : 3000.0,
       "releaseDate" : "2023-06-28",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 3.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : null,
+      "wishlistId" : null,
+      "cartId" : null
+    }, {
+      "assetId" : 27,
+      "assetName" : "dirty boy",
+      "price" : 2000.0,
+      "discount" : 0,
+      "discountPrice" : 2000.0,
+      "releaseDate" : "2023-06-27",
+      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -3822,38 +3822,38 @@ Content-Length: 1374
   "msg" : "성공",
   "data" : {
     "assetList" : [ {
-      "assetId" : 3,
-      "assetName" : "cute boy",
-      "price" : 3000.0,
+      "assetId" : 9,
+      "assetName" : "pretty boy",
+      "price" : 4000.0,
       "discount" : 0,
-      "discountPrice" : 3000.0,
-      "releaseDate" : "2023-06-03",
+      "discountPrice" : 4000.0,
+      "releaseDate" : "2023-06-09",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 3.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
-      "cartId" : null
+      "cartId" : 21
     }, {
-      "assetId" : 5,
-      "assetName" : "cute runner",
-      "price" : 5000.0,
+      "assetId" : 1,
+      "assetName" : "cute man",
+      "price" : 1000.0,
       "discount" : 0,
-      "discountPrice" : 5000.0,
-      "releaseDate" : "2023-06-05",
+      "discountPrice" : 1000.0,
+      "releaseDate" : "2023-06-01",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
       "rating" : 1.0,
       "reviewCount" : 1,
       "wishCount" : null,
       "wishlistId" : null,
-      "cartId" : 17
+      "cartId" : null
     }, {
-      "assetId" : 4,
-      "assetName" : "cute girl",
-      "price" : 4000.0,
+      "assetId" : 2,
+      "assetName" : "cute woman",
+      "price" : 2000.0,
       "discount" : 0,
-      "discountPrice" : 4000.0,
-      "releaseDate" : "2023-06-04",
+      "discountPrice" : 2000.0,
+      "releaseDate" : "2023-06-02",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
       "rating" : 2.0,
       "reviewCount" : 1,
@@ -3944,7 +3944,7 @@ X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-Content-Length: 1788
+Content-Length: 1790
 
 {
   "status" : 200,
@@ -3958,8 +3958,8 @@ Content-Length: 1788
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-24",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -3971,8 +3971,8 @@ Content-Length: 1788
       "discountPrice" : 3000.0,
       "releaseDate" : "2023-06-23",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 3.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -3984,21 +3984,21 @@ Content-Length: 1788
       "discountPrice" : 2000.0,
       "releaseDate" : "2023-06-22",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 4.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
     }, {
-      "assetId" : 21,
-      "assetName" : "luxury boy",
-      "price" : 1000.0,
+      "assetId" : 20,
+      "assetName" : "luxury woman",
+      "price" : 5000.0,
       "discount" : 0,
-      "discountPrice" : 1000.0,
-      "releaseDate" : "2023-06-21",
+      "discountPrice" : 5000.0,
+      "releaseDate" : "2023-06-20",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 5.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -4087,7 +4087,7 @@ X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-Content-Length: 1779
+Content-Length: 1770
 
 {
   "status" : 200,
@@ -4101,37 +4101,11 @@ Content-Length: 1779
       "discountPrice" : 2000.0,
       "releaseDate" : "2023-06-12",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 4.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : 4,
       "wishlistId" : null,
       "cartId" : 24
-    }, {
-      "assetId" : 11,
-      "assetName" : "pretty runner",
-      "price" : 1000.0,
-      "discount" : 0,
-      "discountPrice" : 1000.0,
-      "releaseDate" : "2023-06-11",
-      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 5.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
-      "wishlistId" : null,
-      "cartId" : 23
-    }, {
-      "assetId" : 10,
-      "assetName" : "pretty girl",
-      "price" : 5000.0,
-      "discount" : 0,
-      "discountPrice" : 5000.0,
-      "releaseDate" : "2023-06-10",
-      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 1.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
-      "wishlistId" : null,
-      "cartId" : 22
     }, {
       "assetId" : 9,
       "assetName" : "pretty boy",
@@ -4140,11 +4114,37 @@ Content-Length: 1779
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-09",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : 21
+    }, {
+      "assetId" : 10,
+      "assetName" : "pretty girl",
+      "price" : 5000.0,
+      "discount" : 0,
+      "discountPrice" : 5000.0,
+      "releaseDate" : "2023-06-10",
+      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : 4,
+      "wishlistId" : null,
+      "cartId" : 22
+    }, {
+      "assetId" : 11,
+      "assetName" : "pretty runner",
+      "price" : 1000.0,
+      "discount" : 0,
+      "discountPrice" : 1000.0,
+      "releaseDate" : "2023-06-11",
+      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : 4,
+      "wishlistId" : null,
+      "cartId" : 23
     } ],
     "size" : 4,
     "currentPage" : 0,
@@ -4255,19 +4255,6 @@ Content-Length: 1381
   "msg" : "성공",
   "data" : {
     "assetList" : [ {
-      "assetId" : 20,
-      "assetName" : "luxury woman",
-      "price" : 5000.0,
-      "discount" : 0,
-      "discountPrice" : 5000.0,
-      "releaseDate" : "2023-06-20",
-      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 1.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
-      "wishlistId" : null,
-      "cartId" : null
-    }, {
       "assetId" : 19,
       "assetName" : "luxury man",
       "price" : 4000.0,
@@ -4275,8 +4262,21 @@ Content-Length: 1381
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-19",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : null,
+      "wishlistId" : null,
+      "cartId" : null
+    }, {
+      "assetId" : 20,
+      "assetName" : "luxury woman",
+      "price" : 5000.0,
+      "discount" : 0,
+      "discountPrice" : 5000.0,
+      "releaseDate" : "2023-06-20",
+      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -4288,8 +4288,8 @@ Content-Length: 1381
       "discountPrice" : 1000.0,
       "releaseDate" : "2023-06-21",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 5.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -4396,7 +4396,7 @@ Content-Length: 1369
       "discountPrice" : 2000.0,
       "releaseDate" : "2023-06-07",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 4.0,
+      "rating" : 2.0,
       "reviewCount" : 1,
       "wishCount" : null,
       "wishlistId" : null,
@@ -4422,8 +4422,8 @@ Content-Length: 1369
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-09",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : 5
@@ -4548,8 +4548,8 @@ Content-Length: 575
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-19",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -4656,8 +4656,8 @@ Content-Length: 576
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-19",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -4768,7 +4768,7 @@ X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-Content-Length: 1783
+Content-Length: 1775
 
 {
   "status" : 200,
@@ -4782,8 +4782,8 @@ Content-Length: 1783
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-19",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -4795,9 +4795,9 @@ Content-Length: 1783
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-14",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : 4,
       "wishlistId" : null,
       "cartId" : null
     }, {
@@ -4808,21 +4808,21 @@ Content-Length: 1783
       "discountPrice" : 3000.0,
       "releaseDate" : "2023-06-13",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 3.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : 4,
       "wishlistId" : null,
       "cartId" : null
     }, {
-      "assetId" : 24,
-      "assetName" : "luxury dancer",
-      "price" : 4000.0,
+      "assetId" : 22,
+      "assetName" : "luxury girl",
+      "price" : 2000.0,
       "discount" : 0,
-      "discountPrice" : 4000.0,
-      "releaseDate" : "2023-06-24",
+      "discountPrice" : 2000.0,
+      "releaseDate" : "2023-06-22",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -4896,7 +4896,7 @@ X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-Content-Length: 4187
+Content-Length: 4181
 
 {
   "status" : 200,
@@ -4910,8 +4910,8 @@ Content-Length: 4187
       "discountPrice" : 5000.0,
       "releaseDate" : "2023-06-25",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 1.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -4923,8 +4923,8 @@ Content-Length: 4187
       "discountPrice" : 1000.0,
       "releaseDate" : "2023-06-26",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 5.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -4936,8 +4936,8 @@ Content-Length: 4187
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-19",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -4949,21 +4949,8 @@ Content-Length: 4187
       "discountPrice" : 5000.0,
       "releaseDate" : "2023-06-20",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 1.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
-      "wishlistId" : null,
-      "cartId" : null
-    }, {
-      "assetId" : 14,
-      "assetName" : "sexy woman",
-      "price" : 4000.0,
-      "discount" : 0,
-      "discountPrice" : 4000.0,
-      "releaseDate" : "2023-06-14",
-      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -4975,11 +4962,37 @@ Content-Length: 4187
       "discountPrice" : 3000.0,
       "releaseDate" : "2023-06-13",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 3.0,
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : 4,
+      "wishlistId" : null,
+      "cartId" : null
+    }, {
+      "assetId" : 14,
+      "assetName" : "sexy woman",
+      "price" : 4000.0,
+      "discount" : 0,
+      "discountPrice" : 4000.0,
+      "releaseDate" : "2023-06-14",
+      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : 4,
+      "wishlistId" : null,
+      "cartId" : null
+    }, {
+      "assetId" : 7,
+      "assetName" : "pretty man",
+      "price" : 2000.0,
+      "discount" : 0,
+      "discountPrice" : 2000.0,
+      "releaseDate" : "2023-06-07",
+      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
+      "rating" : 2.0,
       "reviewCount" : 1,
       "wishCount" : null,
       "wishlistId" : null,
-      "cartId" : null
+      "cartId" : 19
     }, {
       "assetId" : 8,
       "assetName" : "pretty woman",
@@ -4994,19 +5007,6 @@ Content-Length: 4187
       "wishlistId" : null,
       "cartId" : 20
     }, {
-      "assetId" : 7,
-      "assetName" : "pretty man",
-      "price" : 2000.0,
-      "discount" : 0,
-      "discountPrice" : 2000.0,
-      "releaseDate" : "2023-06-07",
-      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 4.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
-      "wishlistId" : null,
-      "cartId" : 19
-    }, {
       "assetId" : 1,
       "assetName" : "cute man",
       "price" : 1000.0,
@@ -5014,7 +5014,7 @@ Content-Length: 4187
       "discountPrice" : 1000.0,
       "releaseDate" : "2023-06-01",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 5.0,
+      "rating" : 1.0,
       "reviewCount" : 1,
       "wishCount" : null,
       "wishlistId" : null,
@@ -5027,7 +5027,7 @@ Content-Length: 4187
       "discountPrice" : 2000.0,
       "releaseDate" : "2023-06-02",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 4.0,
+      "rating" : 2.0,
       "reviewCount" : 1,
       "wishCount" : null,
       "wishlistId" : null,
@@ -5134,60 +5134,8 @@ Content-Length: 2595
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-24",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
-      "wishlistId" : null,
-      "cartId" : null
-    }, {
-      "assetId" : 22,
-      "assetName" : "luxury girl",
-      "price" : 2000.0,
-      "discount" : 0,
-      "discountPrice" : 2000.0,
-      "releaseDate" : "2023-06-22",
-      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 4.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
-      "wishlistId" : null,
-      "cartId" : null
-    }, {
-      "assetId" : 23,
-      "assetName" : "luxury runner",
-      "price" : 3000.0,
-      "discount" : 0,
-      "discountPrice" : 3000.0,
-      "releaseDate" : "2023-06-23",
-      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 3.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
-      "wishlistId" : null,
-      "cartId" : null
-    }, {
-      "assetId" : 20,
-      "assetName" : "luxury woman",
-      "price" : 5000.0,
-      "discount" : 0,
-      "discountPrice" : 5000.0,
-      "releaseDate" : "2023-06-20",
-      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 1.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
-      "wishlistId" : null,
-      "cartId" : null
-    }, {
-      "assetId" : 21,
-      "assetName" : "luxury boy",
-      "price" : 1000.0,
-      "discount" : 0,
-      "discountPrice" : 1000.0,
-      "releaseDate" : "2023-06-21",
-      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 5.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -5199,8 +5147,60 @@ Content-Length: 2595
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-19",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : null,
+      "wishlistId" : null,
+      "cartId" : null
+    }, {
+      "assetId" : 20,
+      "assetName" : "luxury woman",
+      "price" : 5000.0,
+      "discount" : 0,
+      "discountPrice" : 5000.0,
+      "releaseDate" : "2023-06-20",
+      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : null,
+      "wishlistId" : null,
+      "cartId" : null
+    }, {
+      "assetId" : 21,
+      "assetName" : "luxury boy",
+      "price" : 1000.0,
+      "discount" : 0,
+      "discountPrice" : 1000.0,
+      "releaseDate" : "2023-06-21",
+      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : null,
+      "wishlistId" : null,
+      "cartId" : null
+    }, {
+      "assetId" : 22,
+      "assetName" : "luxury girl",
+      "price" : 2000.0,
+      "discount" : 0,
+      "discountPrice" : 2000.0,
+      "releaseDate" : "2023-06-22",
+      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : null,
+      "wishlistId" : null,
+      "cartId" : null
+    }, {
+      "assetId" : 23,
+      "assetName" : "luxury runner",
+      "price" : 3000.0,
+      "discount" : 0,
+      "discountPrice" : 3000.0,
+      "releaseDate" : "2023-06-23",
+      "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : null
@@ -5293,7 +5293,7 @@ X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
-Content-Length: 2565
+Content-Length: 2556
 
 {
   "status" : 200,
@@ -5307,9 +5307,9 @@ Content-Length: 2565
       "discountPrice" : 1000.0,
       "releaseDate" : "2023-06-11",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 5.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : 4,
       "wishlistId" : 2,
       "cartId" : 7
     }, {
@@ -5320,9 +5320,9 @@ Content-Length: 2565
       "discountPrice" : 2000.0,
       "releaseDate" : "2023-06-12",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 4.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : 4,
       "wishlistId" : 3,
       "cartId" : 8
     }, {
@@ -5333,7 +5333,7 @@ Content-Length: 2565
       "discountPrice" : 2000.0,
       "releaseDate" : "2023-06-07",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 4.0,
+      "rating" : 2.0,
       "reviewCount" : 1,
       "wishCount" : null,
       "wishlistId" : null,
@@ -5359,8 +5359,8 @@ Content-Length: 2565
       "discountPrice" : 4000.0,
       "releaseDate" : "2023-06-09",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 2.0,
-      "reviewCount" : 1,
+      "rating" : 0.0,
+      "reviewCount" : 0,
       "wishCount" : null,
       "wishlistId" : null,
       "cartId" : 5
@@ -5372,9 +5372,9 @@ Content-Length: 2565
       "discountPrice" : 5000.0,
       "releaseDate" : "2023-06-10",
       "thumbnailUrl" : "thumbnail/2023/06/27/f2b145c6-dd28-4640-b23c-0dbc729ed94e.png",
-      "rating" : 1.0,
-      "reviewCount" : 1,
-      "wishCount" : null,
+      "rating" : 0.0,
+      "reviewCount" : 0,
+      "wishCount" : 4,
       "wishlistId" : 1,
       "cartId" : 6
     } ],
@@ -8369,7 +8369,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJqd3RzdHVkeSIsInJvbGUiOiJVU0VSIiwiaWQiOjEsImV4cCI6MTY4ODAzMDY0N30.8eb25WaiIN5sqQ_Lc-EdW2DwC-MulC3CS5PEqw0-HI8wz0S6NvS2offwjpsbUZFRR1ouJx2APH682eGgL2qFog
+Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJqd3RzdHVkeSIsInJvbGUiOiJVU0VSIiwiaWQiOjEsImV4cCI6MTY4ODA0MTkyNH0.13OPM4JUIfC9EjYJenguPo_dVsOShTVvrBjisrtmwaf4faUPrWn_gobVOXAO5D95EIS7YV-dyqulKwi8xJ466Q
 Content-Type: application/json;charset=UTF-8
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
@@ -11662,7 +11662,7 @@ Content-Length: 86
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-06-28 16:33:41 +0900
+Last updated 2023-06-28 21:16:46 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">


### PR DESCRIPTION
## Motivation

- 에셋 조회 오류 & 에셋 등록 오류 해결

resolved #14 #99 #106 

## Proposed Changes

- #14 카테고리별 에셋 조회시 태그가 없는 에셋이 조회되지 않는 문제를 해결
  - inner join을 사용해서 태그를 에셋태그 테이블에 join하면 에셋태그에서 태그id가 null인 레코드는 조회되지 않는다.
  - inner join 대신 left join을 사용해서 해결
  
- #99 이미 생성되어 있는 태그로 에셋태그 테이블에 등록이 되지 않는 문제를 해결
  - 사용자가 에셋을 등록할 때 기존에 있는 태그를 붙이는 경우에 대해 코드 작성을 하지 않아서 문제가 발생. 
  - 태그네임 조회 대신 태그객체 리스트를 조회하고 서비스에서 가공해서 사용.
  - 태그객체 리스트에서 리퀘스트로 받은 태그네임으로 객체를 추출해서 태그에셋 저장시 사용.
  
- #106 관리자 에셋 조회시 updateAt이 null인 경우 예외발생 해결
  - response dto에서 updateAt이 null인 경우 조건문을 추가해서 해결
